### PR TITLE
fix(ci): wrap hvigorw for Windows es2abc env + repair ArkTS blockers

### DIFF
--- a/entry/src/main/ets/common/CoreFirmwareRepository.ets
+++ b/entry/src/main/ets/common/CoreFirmwareRepository.ets
@@ -1,0 +1,114 @@
+import { common } from '@kit.AbilityKit'
+import { fileIo as fs } from '@kit.CoreFileKit'
+
+export interface CoreFirmwareDependencyRule {
+  coreId: string
+  coreName: string
+  requiredFiles: string[]
+  hint: string
+}
+
+export interface CoreFirmwareDependencyState {
+  coreId: string
+  coreName: string
+  statusText: string
+  detailText: string
+  foundFilesText: string
+  missingFilesText: string
+  hasDependencies: boolean
+}
+
+export const CORE_FIRMWARE_DEPENDENCY_RULES: CoreFirmwareDependencyRule[] = [
+  {
+    coreId: 'melonds',
+    coreName: 'melonDS',
+    requiredFiles: ['bios7.bin', 'bios9.bin', 'firmware.bin'],
+    hint: '建议放入 filesDir/system/ 下的 BIOS 与固件文件'
+  },
+  {
+    coreId: 'mednafen_psx_hw',
+    coreName: 'Beetle PSX HW',
+    requiredFiles: ['scph5500.bin', 'scph5501.bin', 'scph5502.bin'],
+    hint: '至少准备一份有效的 PS1 BIOS'
+  },
+  {
+    coreId: 'pcsx_rearmed',
+    coreName: 'PCSX-ReARMed',
+    requiredFiles: ['scph5500.bin', 'scph5501.bin', 'scph5502.bin'],
+    hint: '建议准备 PS1 BIOS 以提升兼容性'
+  }
+]
+
+export async function loadSystemFirmwareEntries(context: common.UIAbilityContext): Promise<string[]> {
+  const systemDir = buildSystemFirmwareDir(context.filesDir)
+  try {
+    return await fs.listFile(systemDir)
+  } catch (_err) {
+    return []
+  }
+}
+
+export function buildCoreFirmwareDependencyState(
+  coreId: string,
+  systemEntries: string[]
+): CoreFirmwareDependencyState {
+  const rule = CORE_FIRMWARE_DEPENDENCY_RULES.find((item: CoreFirmwareDependencyRule) => item.coreId === coreId)
+  if (!rule) {
+    return {
+      coreId: coreId,
+      coreName: coreId,
+      statusText: '无需额外固件',
+      detailText: '当前核心未配置额外 BIOS / firmware 依赖',
+      foundFilesText: '未命中依赖规则',
+      missingFilesText: '无',
+      hasDependencies: false
+    }
+  }
+
+  const availableEntries = new Set<string>()
+  systemEntries.forEach((entry: string) => {
+    availableEntries.add(normalizeFirmwareName(entry))
+  })
+
+  const foundFiles: string[] = []
+  const missingFiles: string[] = []
+  rule.requiredFiles.forEach((fileName: string) => {
+    const normalized = normalizeFirmwareName(fileName)
+    if (availableEntries.has(normalized)) {
+      foundFiles.push(fileName)
+      return
+    }
+    missingFiles.push(fileName)
+  })
+
+  const statusText = missingFiles.length === 0 ?
+    `固件就绪 ${foundFiles.length}/${rule.requiredFiles.length}` :
+    (foundFiles.length > 0 ?
+      `部分缺失 ${foundFiles.length}/${rule.requiredFiles.length}` :
+      `缺少固件 0/${rule.requiredFiles.length}`)
+
+  return {
+    coreId: rule.coreId,
+    coreName: rule.coreName,
+    statusText: statusText,
+    detailText: rule.hint,
+    foundFilesText: foundFiles.length > 0 ? `已发现: ${foundFiles.join(', ')}` : '未发现对应 BIOS / firmware 文件',
+    missingFilesText: missingFiles.length > 0 ? `缺少: ${missingFiles.join(', ')}` : '无缺失项',
+    hasDependencies: true
+  }
+}
+
+export function formatCoreFirmwarePathList(files: string[]): string {
+  if (files.length === 0) {
+    return '无'
+  }
+  return files.map((fileName: string) => `system/${fileName}`).join(' / ')
+}
+
+function buildSystemFirmwareDir(filesDir: string): string {
+  return `${filesDir}/system`
+}
+
+function normalizeFirmwareName(value: string): string {
+  return `${value}`.trim().toLowerCase()
+}

--- a/entry/src/main/ets/common/LibraryRepository.ets
+++ b/entry/src/main/ets/common/LibraryRepository.ets
@@ -338,6 +338,12 @@ export async function getLibraryRecordByRomFile(
   return records.find((record: LibraryRecord) => record.romFile === romFile)
 }
 
+export async function loadAllLibraryRecords(
+  context: common.UIAbilityContext
+): Promise<LibraryRecord[]> {
+  return await loadLibraryIndex(context)
+}
+
 export async function updateLibraryRecordCover(
   context: common.UIAbilityContext,
   romFile: string,

--- a/entry/src/main/ets/common/RomImportService.ets
+++ b/entry/src/main/ets/common/RomImportService.ets
@@ -80,10 +80,6 @@ interface FileIoCompat {
   stat(path: string): Promise<FileStatCompat>
 }
 
-interface AsyncReadResultCompat {
-  buffer?: ArrayBuffer
-}
-
 interface PickerSelectOptionsCompat {
   maxSelectNumber: number
 }
@@ -750,14 +746,18 @@ async function copyFileFromUri(
       if (shouldCancel?.()) {
         throw new ImportCanceledError(readSize)
       }
-      const readResult = await fs.read(srcFile.fd, bufSize, readSize) as AsyncReadResultCompat
-      const chunk = readResult.buffer
-      const readLen = chunk ? chunk.byteLength : 0
+      const chunk = new ArrayBuffer(bufSize)
+      const readOptions: ReadOptions = {
+        offset: 0,
+        length: bufSize
+      }
+      const readLen = await fs.read(srcFile.fd, chunk, readOptions)
       if (readLen <= 0) {
         break
       }
       readSize += readLen
-      await fs.write(destFile.fd, chunk as ArrayBuffer)
+      const chunkToWrite = readLen >= chunk.byteLength ? chunk : chunk.slice(0, readLen)
+      await fs.write(destFile.fd, chunkToWrite)
       onChunkCopied?.(readSize)
       if (readSize % (1024 * 1024) === 0) {
         await Promise.resolve()

--- a/entry/src/main/ets/common/RuntimeRenderSettingsRepository.ets
+++ b/entry/src/main/ets/common/RuntimeRenderSettingsRepository.ets
@@ -1,0 +1,139 @@
+import { common } from '@kit.AbilityKit'
+import { fileIo as fs } from '@kit.CoreFileKit'
+
+export interface RuntimeRenderSettingsProfile {
+  version: number
+  scalingMode: number
+  softwareMaxPresetIndex: number
+  hwRenderAllowed: boolean
+  updatedAt: number
+}
+
+const RUNTIME_RENDER_SETTINGS_VERSION = 1
+const RUNTIME_RENDER_SETTINGS_DIR_NAME = 'runtime'
+const RUNTIME_RENDER_SETTINGS_FILE_NAME = 'render_settings.json'
+
+export function createDefaultRuntimeRenderSettingsProfile(): RuntimeRenderSettingsProfile {
+  return {
+    version: RUNTIME_RENDER_SETTINGS_VERSION,
+    scalingMode: 2,
+    softwareMaxPresetIndex: 1,
+    hwRenderAllowed: true,
+    updatedAt: 0
+  }
+}
+
+export async function loadRuntimeRenderSettingsProfile(
+  context: common.UIAbilityContext
+): Promise<RuntimeRenderSettingsProfile> {
+  const path = buildRuntimeRenderSettingsPath(context.filesDir)
+  try {
+    const text = await fs.readText(path)
+    if (!text || text.length === 0) {
+      return createDefaultRuntimeRenderSettingsProfile()
+    }
+    return normalizeRuntimeRenderSettingsProfile(JSON.parse(text) as RuntimeRenderSettingsProfile)
+  } catch (_err) {
+    return createDefaultRuntimeRenderSettingsProfile()
+  }
+}
+
+export async function saveRuntimeRenderSettingsProfile(
+  context: common.UIAbilityContext,
+  profile: RuntimeRenderSettingsProfile
+): Promise<RuntimeRenderSettingsProfile> {
+  await ensureDirExists(buildRuntimeRenderSettingsDirPath(context.filesDir))
+  const normalized = normalizeRuntimeRenderSettingsProfile(profile)
+  const nextProfile: RuntimeRenderSettingsProfile = {
+    version: RUNTIME_RENDER_SETTINGS_VERSION,
+    scalingMode: normalized.scalingMode,
+    softwareMaxPresetIndex: normalized.softwareMaxPresetIndex,
+    hwRenderAllowed: normalized.hwRenderAllowed,
+    updatedAt: Date.now()
+  }
+  let file: fs.File | undefined = undefined
+  try {
+    file = await fs.open(
+      buildRuntimeRenderSettingsPath(context.filesDir),
+      fs.OpenMode.WRITE_ONLY | fs.OpenMode.CREATE | fs.OpenMode.TRUNC
+    )
+    await fs.write(file.fd, JSON.stringify(nextProfile, null, 2))
+  } finally {
+    if (file) {
+      await fs.close(file.fd)
+    }
+  }
+  return nextProfile
+}
+
+export function normalizeRuntimeRenderSettingsProfile(
+  profile: RuntimeRenderSettingsProfile
+): RuntimeRenderSettingsProfile {
+  return {
+    version: RUNTIME_RENDER_SETTINGS_VERSION,
+    scalingMode: clampRenderMode(profile.scalingMode),
+    softwareMaxPresetIndex: clampSoftwarePresetIndex(profile.softwareMaxPresetIndex),
+    hwRenderAllowed: Boolean(profile.hwRenderAllowed),
+    updatedAt: Number(profile.updatedAt) || 0
+  }
+}
+
+export function describeRenderMode(mode: number): string {
+  const safeMode = clampRenderMode(mode)
+  if (safeMode === 0) {
+    return '硬件渲染'
+  }
+  if (safeMode === 1) {
+    return '软件渲染'
+  }
+  return 'GLES 渲染'
+}
+
+export function describeSoftwareResolutionPreset(index: number): string {
+  const safeIndex = clampSoftwarePresetIndex(index)
+  if (safeIndex === 0) {
+    return '640x480'
+  }
+  if (safeIndex === 2) {
+    return '1920x1080'
+  }
+  return '1280x720'
+}
+
+function clampRenderMode(mode: number): number {
+  const safeMode = Math.floor(Number(mode) || 0)
+  if (safeMode < 0) {
+    return 0
+  }
+  if (safeMode > 2) {
+    return 2
+  }
+  return safeMode
+}
+
+function clampSoftwarePresetIndex(index: number): number {
+  const safeIndex = Math.floor(Number(index) || 0)
+  if (safeIndex < 0) {
+    return 0
+  }
+  if (safeIndex > 2) {
+    return 2
+  }
+  return safeIndex
+}
+
+function buildRuntimeRenderSettingsDirPath(filesDir: string): string {
+  return `${filesDir}/${RUNTIME_RENDER_SETTINGS_DIR_NAME}`
+}
+
+function buildRuntimeRenderSettingsPath(filesDir: string): string {
+  return `${buildRuntimeRenderSettingsDirPath(filesDir)}/${RUNTIME_RENDER_SETTINGS_FILE_NAME}`
+}
+
+async function ensureDirExists(path: string): Promise<void> {
+  try {
+    await fs.mkdir(path, true)
+  } catch (_err) {
+    return
+  }
+}

--- a/entry/src/main/ets/pages/SettingsPage.ets
+++ b/entry/src/main/ets/pages/SettingsPage.ets
@@ -29,6 +29,11 @@ interface SettingOptionItem {
   isActive: boolean
 }
 
+interface SoftwareResolutionPreset {
+  width: number
+  height: number
+}
+
 @Entry
 @Component
 struct SettingsPage {
@@ -129,6 +134,16 @@ struct SettingsPage {
     return '仅打开本地滤镜预览，不会写入当前运行时 shader preset'
   }
 
+  private cloneRenderProfile(): RuntimeRenderSettingsProfile {
+    return {
+      version: this.renderProfile.version,
+      scalingMode: this.renderProfile.scalingMode,
+      softwareMaxPresetIndex: this.renderProfile.softwareMaxPresetIndex,
+      hwRenderAllowed: this.renderProfile.hwRenderAllowed,
+      updatedAt: this.renderProfile.updatedAt
+    }
+  }
+
   aboutToAppear(): void {
     this.pageActive = true
     void this.refreshPageData()
@@ -171,7 +186,7 @@ struct SettingsPage {
     const inputDevices: InputDeviceInfo[] = runtimeInputPortController.listInputDevices()
     const externalNames: string[] = []
     inputDevices.forEach((item: InputDeviceInfo) => {
-      const label = `${item.deviceName}`.trim()
+      const label = `${item.name}`.trim()
       if (label.length > 0) {
         externalNames.push(label)
       }
@@ -244,10 +259,8 @@ struct SettingsPage {
 
   private async toggleHwRenderAllowed(): Promise<void> {
     const nextValue = !this.renderProfile.hwRenderAllowed
-    const nextProfile: RuntimeRenderSettingsProfile = {
-      ...this.renderProfile,
-      hwRenderAllowed: nextValue
-    }
+    const nextProfile: RuntimeRenderSettingsProfile = this.cloneRenderProfile()
+    nextProfile.hwRenderAllowed = nextValue
     const ok = runtimeRenderSettingsController.setHwRenderAllowed(nextValue)
     this.setRuntimeApplyStatus('GPU Backend', ok)
     if (!ok) {
@@ -258,10 +271,8 @@ struct SettingsPage {
 
   private async cycleRenderMode(): Promise<void> {
     const nextMode = (this.renderProfile.scalingMode + 1) % 3
-    const nextProfile: RuntimeRenderSettingsProfile = {
-      ...this.renderProfile,
-      scalingMode: nextMode
-    }
+    const nextProfile: RuntimeRenderSettingsProfile = this.cloneRenderProfile()
+    nextProfile.scalingMode = nextMode
     const okMode = runtimeRenderSettingsController.setScalingMode(nextMode)
     let okResolution = true
     if (nextMode === 1) {
@@ -278,11 +289,9 @@ struct SettingsPage {
 
   private async cycleSoftwareResolutionPreset(): Promise<void> {
     const nextPreset = (this.renderProfile.softwareMaxPresetIndex + 1) % 3
-    const nextProfile: RuntimeRenderSettingsProfile = {
-      ...this.renderProfile,
-      scalingMode: 1,
-      softwareMaxPresetIndex: nextPreset
-    }
+    const nextProfile: RuntimeRenderSettingsProfile = this.cloneRenderProfile()
+    nextProfile.scalingMode = 1
+    nextProfile.softwareMaxPresetIndex = nextPreset
     const resolution = this.getSoftwareResolutionForPreset(nextPreset)
     const okMode = runtimeRenderSettingsController.setScalingMode(1)
     const okResolution = runtimeRenderSettingsController.setSoftwareMaxResolution(
@@ -297,7 +306,7 @@ struct SettingsPage {
     await this.persistRenderProfile(nextProfile)
   }
 
-  private getSoftwareResolutionForPreset(index: number): { width: number, height: number } {
+  private getSoftwareResolutionForPreset(index: number): SoftwareResolutionPreset {
     if (index === 0) {
       return { width: 640, height: 480 }
     }
@@ -341,12 +350,14 @@ struct SettingsPage {
       this.telemetryBars = this.createEmptyTelemetryBars()
       return
     }
-    this.telemetryBars = telemetryBars.map((item: LibraryTelemetryBar) => {
-      return {
+    const mappedBars: BarChartItem[] = telemetryBars.map((item: LibraryTelemetryBar): BarChartItem => {
+      const nextBar: BarChartItem = {
         height: item.height * 3.5,
         isPrimary: item.color !== '#22484848'
       }
+      return nextBar
     })
+    this.telemetryBars = mappedBars
   }
 
   @Builder

--- a/hvigorw
+++ b/hvigorw
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "${OS:-}" == "Windows_NT" ]] || [[ "${OSTYPE:-}" == msys* ]] || [[ "${OSTYPE:-}" == cygwin* ]] || [[ "${OSTYPE:-}" == win32* ]]; then
+  comspec_path="${ComSpec:-C:\\Windows\\System32\\cmd.exe}"
+  exec "${comspec_path}" //c "${script_dir}\\hvigorw.bat" "$@"
+fi
+
+if [[ -n "${HARMONY_COMMANDLINE_TOOLS_HOME:-}" ]] && [[ -x "${HARMONY_COMMANDLINE_TOOLS_HOME}/bin/hvigorw" ]]; then
+  exec "${HARMONY_COMMANDLINE_TOOLS_HOME}/bin/hvigorw" "$@"
+fi
+
+if command -v hvigorw >/dev/null 2>&1; then
+  exec "$(command -v hvigorw)" "$@"
+fi
+
+echo "[FAIL] Unable to locate hvigorw. Set HARMONY_COMMANDLINE_TOOLS_HOME or add hvigorw to PATH." >&2
+exit 1

--- a/hvigorw.bat
+++ b/hvigorw.bat
@@ -1,0 +1,31 @@
+@echo off
+setlocal
+
+set "REPO_ROOT=%~dp0"
+if "%REPO_ROOT:~-1%"=="\" set "REPO_ROOT=%REPO_ROOT:~0,-1%"
+
+if not defined ComSpec set "ComSpec=%SystemRoot%\System32\cmd.exe"
+if not exist "%ComSpec%" set "ComSpec=%SystemRoot%\System32\cmd.exe"
+
+set "SYSTEM32_DIR=%SystemRoot%\System32"
+set "POWERSHELL_DIR=%SystemRoot%\System32\WindowsPowerShell\v1.0"
+
+echo %PATH% | find /I "%SYSTEM32_DIR%" >nul
+if errorlevel 1 set "PATH=%SYSTEM32_DIR%;%PATH%"
+
+echo %PATH% | find /I "%POWERSHELL_DIR%" >nul
+if errorlevel 1 set "PATH=%POWERSHELL_DIR%;%PATH%"
+
+if defined HARMONY_HVIGORW_BIN if exist "%HARMONY_HVIGORW_BIN%" goto run_hvigor
+if defined HARMONY_COMMANDLINE_TOOLS_HOME if exist "%HARMONY_COMMANDLINE_TOOLS_HOME%\bin\hvigorw.bat" set "HARMONY_HVIGORW_BIN=%HARMONY_COMMANDLINE_TOOLS_HOME%\bin\hvigorw.bat"
+if not defined HARMONY_HVIGORW_BIN if exist "D:\hongmeng\command-line-tools\bin\hvigorw.bat" set "HARMONY_HVIGORW_BIN=D:\hongmeng\command-line-tools\bin\hvigorw.bat"
+
+:run_hvigor
+if not defined HARMONY_HVIGORW_BIN (
+  echo [FAIL] Unable to locate Harmony hvigorw.bat. 1>&2
+  echo [FAIL] Set HARMONY_HVIGORW_BIN or HARMONY_COMMANDLINE_TOOLS_HOME first. 1>&2
+  exit /b 1
+)
+
+call "%HARMONY_HVIGORW_BIN%" %*
+exit /b %ERRORLEVEL%

--- a/scripts/ci/build_harmony_hap.sh
+++ b/scripts/ci/build_harmony_hap.sh
@@ -5,12 +5,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "${ROOT_DIR}"
 
-if ! command -v hvigorw >/dev/null 2>&1; then
-  echo "[FAIL] hvigorw is required in PATH." >&2
-  exit 1
+hvigorw_bin="${ROOT_DIR}/hvigorw"
+if [[ ! -x "${hvigorw_bin}" ]]; then
+  if ! command -v hvigorw >/dev/null 2>&1; then
+    echo "[FAIL] hvigorw is required in PATH." >&2
+    exit 1
+  fi
+  hvigorw_bin="$(command -v hvigorw)"
 fi
 
-hvigorw_bin="$(command -v hvigorw)"
 if [[ ! -x "${hvigorw_bin}" ]]; then
   echo "[FAIL] hvigorw is not executable: ${hvigorw_bin}" >&2
   exit 1


### PR DESCRIPTION
## Summary
- 封装 `hvigorw` / `hvigorw.bat` 处理 Windows `es2abc` PATH 问题，并同步 `scripts/ci/build_harmony_hap.sh`（commit 0406a03）。
- 新增 `CoreFirmwareRepository` / `RuntimeRenderSettingsRepository`，修补 `LibraryRepository` / `RomImportService` / `SettingsPage` 的 ArkTS workflow 编译阻塞（commit 927d64a）。

## Background
HarmonyOS Full CI/CD 在 run id `26208088701` 失败，本分支后续两次手动重跑（`26209171838`、`26213336555`）均 success。本 PR 让正式 PR 流水线 `harmonyos-pr-ci.yml` 走一遍验证。

## Test plan
- [ ] PR CI（`harmonyos-pr-ci.yml`）通过：hvigor 构建 / codelinter / HAP smoke。
- [ ] 可选：本地 `bash scripts/ci/check_repo_hygiene.sh` + `bash scripts/ci/check_regression_guards.sh` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)