### PR TITLE
perf(ui)+chore(io): tail of 5-21 routing perf + IO close hardening + Chinese copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,7 @@ ArkTS 虚拟手柄 / 键盘 / 触控
 - 新增页面后，必须同步注册到 `entry/src/main/resources/base/profile/main_pages.json`，否则页面跳转可能表面成功但无法正常展示
 - 页面跳转参数必须有明确类型，不要依赖随手拼接的匿名对象透传
 - 当前阶段页面导航仍以 ArkUI `router` / `getUIContext().getRouter()` 与 `main_pages.json` 为准；新增页面必须注册 `main_pages.json`。
+- 底部导航中的顶级 tab（如 `library / engine / input / system`）默认视为平级页面切换，优先使用 `replaceUrl`，不要对平级 tab 使用 `pushUrl` 叠栈；需要保留返回栈时，必须先说明理由。
 - `Navigation + NavPathStack` 只作为后续重构目标；未启动导航架构重构前，不要把局部页面强行改成 Navigation 体系。
 - 如后续正式迁移到 `Navigation`：`Navigation.hideNavBar(true)` 时不要让页面栈为空；需要首屏走栈时先 `pushPath`。
 - 如后续正式迁移到 `Navigation`：不要把返回 `NavDestination()` 的页面直接当作 `Navigation` 的首屏内容，应通过 `navDestination` builder 渲染；根级目的地显式包 `NavDestination().hideTitleBar(true)`。
@@ -357,6 +358,7 @@ ArkTS 虚拟手柄 / 键盘 / 触控
 - 列表刷新必须走响应式数据更新；不要依赖“重新进入页面”或整页重建来掩盖刷新问题
 - 滚动容器中的列表项、卡片项避免做重计算、重复创建重量级对象或层级过深的嵌套结构
 - 不要把几十个同构组件手写展开在页面里
+- 做页面切换性能排障时，先排查路由策略、页面栈增长、`aboutToAppear()` 内同步 native 调用、共享 `backdropBlur` 等高成本链路；不要先入为主把 `Canvas` 当作主因。若要验证 `Canvas`，用“只撤 `Canvas`、保留其余逻辑”的最小实验法。
 
 ### SDK / HarmonyOS 版本适配要求
 - 每次升级 `compileSdkVersion`、`targetSdkVersion` 或相关 Kit 版本时，先检查官方 Upgrade Guide、API diff 与已知问题清单，再决定是否直接改代码。

--- a/entry/src/main/ets/common/GameMetadataRepository.ets
+++ b/entry/src/main/ets/common/GameMetadataRepository.ets
@@ -99,7 +99,10 @@ async function saveMetadataDocument(
     LogHelper.error('GameMetadataRepository', 'Save', `保存本地 metadata 失败: ${message}`)
   } finally {
     if (file) {
-      await fs.close(file.fd)
+      try {
+        await fs.close(file.fd)
+      } catch (_closeErr) {
+      }
     }
   }
 }

--- a/entry/src/main/ets/common/InputLayoutRepository.ets
+++ b/entry/src/main/ets/common/InputLayoutRepository.ets
@@ -75,9 +75,16 @@ export async function saveInputLayoutProfile(
   try {
     file = await fs.open(buildInputLayoutPath(context.filesDir), fs.OpenMode.WRITE_ONLY | fs.OpenMode.CREATE | fs.OpenMode.TRUNC)
     await fs.write(file.fd, JSON.stringify(nextProfile, null, 2))
+  } catch (err) {
+    const message = (err as Error).message || String(err)
+    LogHelper.error('InputLayoutRepository', 'Save', `保存输入布局失败: ${message}`)
+    throw err as Error
   } finally {
     if (file) {
-      await fs.close(file.fd)
+      try {
+        await fs.close(file.fd)
+      } catch (_closeErr) {
+      }
     }
   }
   return nextProfile

--- a/entry/src/main/ets/common/LibraryRepository.ets
+++ b/entry/src/main/ets/common/LibraryRepository.ets
@@ -706,7 +706,10 @@ async function saveLibraryIndexToJson(filesDir: string, records: LibraryRecord[]
     LogHelper.error('LibraryRepository', 'Save', `保存 JSON 索引失败: ${message}`)
   } finally {
     if (file) {
-      await fs.close(file.fd)
+      try {
+        await fs.close(file.fd)
+      } catch (_closeErr) {
+      }
     }
   }
 }

--- a/entry/src/main/ets/common/LibrarySaveFilePurger.ets
+++ b/entry/src/main/ets/common/LibrarySaveFilePurger.ets
@@ -13,7 +13,12 @@ export async function purgeSaveFilesForBaseName(
 ): Promise<LibrarySavePurgeResult> {
   const saveDir = `${context.filesDir}/saves`
   const normalizedBaseName = normalizeContentKey(baseName)
-  const entries = await fs.listFile(saveDir)
+  let entries: string[] = []
+  try {
+    entries = await fs.listFile(saveDir)
+  } catch (err) {
+    throw err as Error
+  }
   if (!shouldContinue()) {
     return { deletedCount: 0, cancelled: true }
   }
@@ -25,7 +30,11 @@ export async function purgeSaveFilesForBaseName(
     if (!shouldContinue()) {
       return { deletedCount: index, cancelled: true }
     }
-    await fs.unlink(`${saveDir}/${candidates[index]}`)
+    try {
+      await fs.unlink(`${saveDir}/${candidates[index]}`)
+    } catch (err) {
+      throw err as Error
+    }
   }
   if (!shouldContinue()) {
     return { deletedCount: candidates.length, cancelled: true }

--- a/entry/src/main/ets/common/RomImportService.ets
+++ b/entry/src/main/ets/common/RomImportService.ets
@@ -766,12 +766,20 @@ async function copyFileFromUri(
         throw new ImportCanceledError(readSize)
       }
     }
+  } catch (err) {
+    throw err as Error
   } finally {
     if (srcFile) {
-      await fs.close(srcFile.fd)
+      try {
+        await fs.close(srcFile.fd)
+      } catch (_closeErr) {
+      }
     }
     if (destFile) {
-      await fs.close(destFile.fd)
+      try {
+        await fs.close(destFile.fd)
+      } catch (_closeErr) {
+      }
     }
   }
 }

--- a/entry/src/main/ets/common/RuntimeRenderSettingsRepository.ets
+++ b/entry/src/main/ets/common/RuntimeRenderSettingsRepository.ets
@@ -58,9 +58,14 @@ export async function saveRuntimeRenderSettingsProfile(
       fs.OpenMode.WRITE_ONLY | fs.OpenMode.CREATE | fs.OpenMode.TRUNC
     )
     await fs.write(file.fd, JSON.stringify(nextProfile, null, 2))
+  } catch (err) {
+    throw err as Error
   } finally {
     if (file) {
-      await fs.close(file.fd)
+      try {
+        await fs.close(file.fd)
+      } catch (_closeErr) {
+      }
     }
   }
   return nextProfile

--- a/entry/src/main/ets/common/SaveStateRepository.ets
+++ b/entry/src/main/ets/common/SaveStateRepository.ets
@@ -65,7 +65,12 @@ export function readSaveStateData(
   fileName: string
 ): ArrayBuffer {
   const targetPath = buildSaveFilePath(context.filesDir, sanitizeFileName(fileName))
-  const stat = fs.statSync(targetPath)
+  let stat: fs.Stat
+  try {
+    stat = fs.statSync(targetPath)
+  } catch (err) {
+    throw err as Error
+  }
   const byteLength = Number(stat.size)
   const data = new ArrayBuffer(byteLength)
   let file: fs.File | undefined = undefined
@@ -80,9 +85,14 @@ export function readSaveStateData(
       return data
     }
     return data.slice(0, Math.max(0, readLength))
+  } catch (err) {
+    throw err as Error
   } finally {
     if (file) {
-      fs.closeSync(file.fd)
+      try {
+        fs.closeSync(file.fd)
+      } catch (_closeErr) {
+      }
     }
   }
 }
@@ -169,9 +179,14 @@ async function saveManifest(
   try {
     file = await fs.open(buildManifestPath(context.filesDir), fs.OpenMode.WRITE_ONLY | fs.OpenMode.CREATE | fs.OpenMode.TRUNC)
     await fs.write(file.fd, JSON.stringify(document, null, 2))
+  } catch (err) {
+    throw err as Error
   } finally {
     if (file) {
-      await fs.close(file.fd)
+      try {
+        await fs.close(file.fd)
+      } catch (_closeErr) {
+      }
     }
   }
 }
@@ -184,9 +199,14 @@ function writeArrayBufferToFile(path: string, data: ArrayBuffer): void {
       length: data.byteLength
     }
     fs.writeSync(file.fd, data, writeOptions)
+  } catch (err) {
+    throw err as Error
   } finally {
     if (file) {
-      fs.closeSync(file.fd)
+      try {
+        fs.closeSync(file.fd)
+      } catch (_closeErr) {
+      }
     }
   }
 }

--- a/entry/src/main/ets/components/EmuBottomNav.ets
+++ b/entry/src/main/ets/components/EmuBottomNav.ets
@@ -53,7 +53,7 @@ export struct EmuBottomNav {
     Row() {
       ForEach(this.items, (item: EmuBottomNavItem) => {
         Stack() {
-          Column({ space: 4 }) {
+          Column({ space: 3 }) {
             EmuIcon({
               name: item.iconName,
               tone: item.isActive ? 'primary' : 'muted',
@@ -61,17 +61,24 @@ export struct EmuBottomNav {
               opacityValue: item.isActive ? 1 : 0.46
             })
 
-            Text(this.getPrimaryLabel(item))
-              .fontSize(10)
+            Text(item.label)
+              .fontSize(11)
               .fontWeight(item.isActive ? FontWeight.Bold : FontWeight.Medium)
-              .fontFamily('monospace')
               .fontColor(item.isActive ? this.activeFontColor : this.inactiveFontColor)
-              .letterSpacing(1.4)
+              .letterSpacing(0.4)
               .maxLines(1)
-              .opacity(item.isActive ? 1 : 0.88)
+              .opacity(item.isActive ? 1 : 0.92)
+
+            Text(this.getPrimaryLabel(item))
+              .fontSize(8)
+              .fontWeight(FontWeight.Medium)
+              .fontColor(item.isActive ? this.activeFontColor : this.inactiveFontColor)
+              .letterSpacing(1.6)
+              .maxLines(1)
+              .opacity(item.isActive ? 0.7 : 0.52)
           }
           .height(EmuMetrics.bottomNavHeight)
-          .padding({ top: 14, bottom: 16 })
+          .padding({ top: 12, bottom: 14 })
           .justifyContent(FlexAlign.Center)
           .alignItems(HorizontalAlign.Center)
 
@@ -101,7 +108,6 @@ export struct EmuBottomNav {
     .height(EmuMetrics.bottomNavHeight)
     .padding({ left: 24, right: 24 })
     .backgroundColor(this.panelBackgroundColor)
-    .backdropBlur(20)
     .border({
       width: { top: 0.5 },
       color: '#33262626',

--- a/entry/src/main/ets/components/LibraryDetailInfoPanel.ets
+++ b/entry/src/main/ets/components/LibraryDetailInfoPanel.ets
@@ -21,26 +21,12 @@ export struct LibraryDetailInfoPanel {
   @Prop telemetryGlowOpacity: number = 0.2
   @Prop overviewText: string = 'Unknown'
   @Prop runtimeSummaryText: string = ''
-  private primaryCells: LibraryDetailSummaryCellData[] = []
-  private extendedCells: LibraryDetailSummaryCellData[] = []
-  private telemetryProfile: number[] = []
+  @Prop primaryCells: LibraryDetailSummaryCellData[] = []
+  @Prop extendedCells: LibraryDetailSummaryCellData[] = []
+  @Prop telemetryProfile: number[] = []
   onToggleDetails?: () => void
-  // Pre-computed row caches to avoid .slice() allocation in build()
-  private cachedTopRow: LibraryDetailSummaryCellData[] = []
-  private cachedBottomRow: LibraryDetailSummaryCellData[] = []
-  private lastCellsRef: LibraryDetailSummaryCellData[] | null = null
-
-  aboutToAppear(): void {
-    this.refreshRowCaches()
-  }
-
-  private refreshRowCaches(): void {
-    if (this.extendedCells !== this.lastCellsRef) {
-      this.lastCellsRef = this.extendedCells
-      this.cachedTopRow = this.extendedCells.slice(0, 2)
-      this.cachedBottomRow = this.extendedCells.slice(2, 4)
-    }
-  }
+  private readonly telemetryVerticalLines: number[] = createIndexRange(13)
+  private readonly telemetryHorizontalLines: number[] = createIndexRange(4)
 
   build() {
     Column({ space: 30 }) {
@@ -181,7 +167,7 @@ export struct LibraryDetailInfoPanel {
 
       Stack() {
         Row({ space: 23 }) {
-          ForEach(createIndexRange(13), (_: number) => {
+          ForEach(this.telemetryVerticalLines, (_: number) => {
             Column()
               .width(1)
               .height('100%')
@@ -192,7 +178,7 @@ export struct LibraryDetailInfoPanel {
         .height('100%')
 
         Column({ space: 16 }) {
-          ForEach(createIndexRange(4), (_: number) => {
+          ForEach(this.telemetryHorizontalLines, (_: number) => {
             Row()
               .width('100%')
               .height(1)

--- a/entry/src/main/ets/components/LibrarySearchPanel.ets
+++ b/entry/src/main/ets/components/LibrarySearchPanel.ets
@@ -15,10 +15,10 @@ export struct LibrarySearchPanel {
   @Prop showSearchResults: boolean = false
   @Prop selectedPlatform: string = 'ALL'
   @Prop spinnerAngle: number = 0
-  private searchResults: LibraryRecord[] = []
-  private telemetryCells: EmuTelemetryCellItem[] = []
-  private telemetryBars: EmuTelemetryBarItem[] = []
-  private platforms: string[] = ['ALL']
+  @Prop searchResults: LibraryRecord[] = []
+  @Prop telemetryCells: EmuTelemetryCellItem[] = []
+  @Prop telemetryBars: EmuTelemetryBarItem[] = []
+  @Prop platforms: string[] = ['ALL']
   onKeywordChange?: (value: string) => void
   onSearchResultLaunch?: (item: LibraryRecord) => void
   onPlatformChange?: (value: string) => void

--- a/entry/src/main/ets/components/RuntimeControlPanel.ets
+++ b/entry/src/main/ets/components/RuntimeControlPanel.ets
@@ -24,10 +24,10 @@ export struct RuntimeControlPanel {
   @Prop soakSummaryText: string = ''
   @Prop switchError: string = ''
 
-  private portOptions: SelectOption[] = []
-  private inputSourceOptions: SelectOption[] = []
-  private coreOptions: SelectOption[] = []
-  private romOptions: SelectOption[] = []
+  @Prop portOptions: SelectOption[] = []
+  @Prop inputSourceOptions: SelectOption[] = []
+  @Prop coreOptions: SelectOption[] = []
+  @Prop romOptions: SelectOption[] = []
   onClose?: () => void
   onPortSelect?: (index: number) => void
   onInputSourceSelect?: (index: number) => void

--- a/entry/src/main/ets/pages/AboutHelpPage.ets
+++ b/entry/src/main/ets/pages/AboutHelpPage.ets
@@ -25,7 +25,7 @@ struct AboutHelpPage {
     { id: 'import', title: '怎么导入游戏？', detail: 'Procedure / Storage / Pathing', value: '使用导入入口选择本地 ROM，导入完成后进入库页同步。' },
     { id: 'input', title: '按键没反应怎么办？', detail: 'Input / Mapping / Calibration', value: '进入 INPUT 页面检查端口映射；布局编辑只保存本地 UI 配置。' },
     { id: 'legal', title: '合规声明', detail: 'Compliance / Licensing / EULA', value: '应用不提供商业 ROM；用户需自行确认 ROM 与 BIOS 使用权。' },
-    { id: 'version', title: '当前版本', detail: 'System Architecture / Build Info', value: 'EMU_CORE_v1.0 / HarmonyOS ArkUI native shell。' }
+    { id: 'version', title: '当前版本', detail: 'System Architecture / Build Info', value: '碳影 / Carbon Shade / HarmonyOS ArkUI native shell。' }
   ]
 
   private onBottomNavClick(key: string): void {
@@ -33,14 +33,8 @@ struct AboutHelpPage {
     if (route.length === 0) {
       return
     }
-    if (key === 'library') {
-      this.getUIContext().getRouter().replaceUrl({ url: route }).catch((err: Error) => {
-        console.error(`[AboutHelpPage] replaceUrl ${route} failed: ${err.message}`)
-      })
-      return
-    }
-    this.getUIContext().getRouter().pushUrl({ url: route }).catch((err: Error) => {
-      console.error(`[AboutHelpPage] pushUrl ${route} failed: ${err.message}`)
+    this.getUIContext().getRouter().replaceUrl({ url: route }).catch((err: Error) => {
+      console.error(`[AboutHelpPage] replaceUrl ${route} failed: ${err.message}`)
     })
   }
 
@@ -65,7 +59,7 @@ struct AboutHelpPage {
         .fontColor(EmuColors.onSurface)
         .letterSpacing(0)
 
-      Text('EMU_CORE 是基于 libretro 的本地模拟运行壳。页面只描述当前已接入的本地能力；未接入联网资料与远端服务时会显示 UNKNOWN 或 NOT CONFIGURED。')
+      Text('碳影是基于 libretro 的本地模拟运行壳。当前页面仅展示已接入的本地能力；联网资料与远端服务尚未纳入当前版本。')
         .fontSize(13)
         .fontColor(EmuColors.onSurfaceVariant)
         .lineHeight(20)
@@ -80,7 +74,7 @@ struct AboutHelpPage {
     Column({ space: 14 }) {
       Row() {
         Column({ space: 4 }) {
-          Text('Core Version')
+          Text('当前版本')
             .fontSize(10)
                         .fontColor(EmuColors.secondary)
             .letterSpacing(1.4)
@@ -98,7 +92,7 @@ struct AboutHelpPage {
         .alignItems(HorizontalAlign.Start)
 
         Column({ space: 4 }) {
-          Text('Data Source')
+          Text('数据来源')
             .fontSize(10)
                         .fontColor(EmuColors.secondary)
             .letterSpacing(1.4)
@@ -168,7 +162,7 @@ struct AboutHelpPage {
   @Builder
   private HelpList() {
     Column({ space: 0 }) {
-      Text('DOCUMENTATION & LEGAL')
+      Text('文档与说明')
         .fontSize(10)
                 .fontColor(EmuColors.secondary)
         .letterSpacing(2)
@@ -191,7 +185,7 @@ struct AboutHelpPage {
           .height(2)
           .backgroundColor(EmuColors.primary)
 
-        Text('DESIGNED FOR LOCAL\nLIBRETRO SHELL.\nHARMONYOS // ARKUI //\nLIBRETRO')
+        Text('面向本地模拟体验\n构建于 HarmonyOS ArkUI\n基于 libretro 运行架构')
           .fontSize(13)
                     .fontColor(EmuColors.onSurfaceVariant)
           .letterSpacing(1.6)
@@ -225,9 +219,9 @@ struct AboutHelpPage {
   build() {
     Column() {
       EmuHeaderBar({
-        titleText: 'EMU_CORE_v1.0',
+        titleText: '碳影 / Carbon Shade',
         titleIcon: 'memory',
-        rightLabel: 'SYSTEM',
+        rightLabel: '系统',
         rightIcon: 'settings_input_component',
         activeTextColor: EmuColors.primary,
         iconSize: 16,

--- a/entry/src/main/ets/pages/CoreManagerPage.ets
+++ b/entry/src/main/ets/pages/CoreManagerPage.ets
@@ -3,6 +3,12 @@ import { fileIo as fs } from '@kit.CoreFileKit'
 import { EmuBottomNav, EmuBottomNavItem } from '../components/EmuBottomNav'
 import { EmuHeaderBar } from '../components/EmuAppShell'
 import { EmuIcon } from '../components/EmuIcon'
+import {
+  buildCoreFirmwareDependencyState,
+  CoreFirmwareDependencyState,
+  formatCoreFirmwarePathList,
+  loadSystemFirmwareEntries
+} from '../common/CoreFirmwareRepository'
 import { EmuColors } from '../common/EmuUiTokens'
 import { CoreConfig, LIBRETRO_CORE_CATALOG } from '../common/LibretroCoreCatalog'
 import { getEmuBottomNavTargetRoute } from '../common/RouteHelper'
@@ -14,14 +20,23 @@ interface ManagedCoreItem {
   soFile: string
   status: string
   installed: boolean
+  firmwareStatus: string
+  firmwareDetail: string
+  firmwareFoundText: string
+  firmwareMissingText: string
+  hasFirmwareDependencies: boolean
 }
 
 @Entry
 @Component
 struct CoreManagerPage {
   @State private coreItems: ManagedCoreItem[] = []
-  @State private statusText: string = 'SCANNING_LOCAL_CORES'
+  @State private statusText: string = '正在扫描本地核心'
   @State private selectedCoreId: string = ''
+  @State private firmwareSummaryText: string = '正在读取本地 system 目录'
+  @State private firmwareFilesText: string = 'system/ 尚未扫描'
+  @State private firmwareDirectoryText: string = 'filesDir/system'
+  @State private remoteUpdateText: string = '当前构建未配置远端 core / firmware 仓库'
   private pageActive: boolean = false
   private coreRefreshToken: number = 0
   private readonly navItems: EmuBottomNavItem[] = [
@@ -54,29 +69,42 @@ struct CoreManagerPage {
     const token = this.beginCoreRefresh()
     const context = this.getUIContext().getHostContext() as common.UIAbilityContext
     if (!context) {
-      this.statusText = 'CONTEXT_MISSING'
+      this.statusText = '上下文不可用'
       this.coreItems = this.buildCatalogItems()
       return
     }
     const nextItems: ManagedCoreItem[] = []
     const catalogItems = this.buildCatalogItems()
+    this.firmwareDirectoryText = `${context.filesDir}/system`
+    const systemEntries = await loadSystemFirmwareEntries(context)
+    if (!this.isCurrentCoreRefresh(token)) {
+      return
+    }
+    this.firmwareFilesText = formatCoreFirmwarePathList(systemEntries)
     for (let index = 0; index < catalogItems.length; index += 1) {
       const item = catalogItems[index]
       const installed = await this.hasCoreFile(context, item.soFile)
       if (!this.isCurrentCoreRefresh(token)) {
         return
       }
+      const firmwareState: CoreFirmwareDependencyState = buildCoreFirmwareDependencyState(item.id, systemEntries)
       nextItems.push({
         id: item.id,
         name: item.name,
         platform: item.platform,
         soFile: item.soFile,
-        status: installed ? 'INSTALLED' : 'NOT_FOUND',
-        installed: installed
+        status: installed ? '已安装' : '未找到',
+        installed: installed,
+        firmwareStatus: firmwareState.statusText,
+        firmwareDetail: firmwareState.detailText,
+        firmwareFoundText: firmwareState.foundFilesText,
+        firmwareMissingText: firmwareState.missingFilesText,
+        hasFirmwareDependencies: firmwareState.hasDependencies
       })
     }
     this.coreItems = nextItems
     this.statusText = this.buildStatusText(nextItems)
+    this.firmwareSummaryText = this.buildFirmwareSummaryText(nextItems, systemEntries)
   }
 
   private async hasCoreFile(context: common.UIAbilityContext, soFile: string): Promise<boolean> {
@@ -100,7 +128,21 @@ struct CoreManagerPage {
         installedCount += 1
       }
     })
-    return `${installedCount}/${items.length}_LOCAL_CORES_READY`
+    return `已安装 ${installedCount}/${items.length} 个本地核心`
+  }
+
+  private buildFirmwareSummaryText(items: ManagedCoreItem[], systemEntries: string[]): string {
+    const dependencyItems = items.filter((item: ManagedCoreItem) => item.hasFirmwareDependencies)
+    if (dependencyItems.length === 0) {
+      return `system/ 已扫描 · ${systemEntries.length} 个文件`
+    }
+    let readyCount = 0
+    dependencyItems.forEach((item: ManagedCoreItem) => {
+      if (item.firmwareMissingText === '无缺失项') {
+        readyCount += 1
+      }
+    })
+    return `${readyCount}/${dependencyItems.length} 个需固件核心已就绪`
   }
 
   private buildCatalogItems(): ManagedCoreItem[] {
@@ -113,8 +155,13 @@ struct CoreManagerPage {
         name: config.name,
         platform: config.description,
         soFile: config.soFile,
-        status: 'LOCAL',
-        installed: false
+        status: '待扫描',
+        installed: false,
+        firmwareStatus: '尚未扫描',
+        firmwareDetail: '等待读取 system/ 目录',
+        firmwareFoundText: '尚未扫描',
+        firmwareMissingText: '尚未扫描',
+        hasFirmwareDependencies: false
       })
     }
     return items
@@ -125,23 +172,17 @@ struct CoreManagerPage {
     if (route.length === 0) {
       return
     }
-    if (key === 'library') {
-      this.getUIContext().getRouter().replaceUrl({ url: route }).catch((err: Error) => {
-        console.error(`[CoreManagerPage] replaceUrl ${route} failed: ${err.message}`)
-      })
-      return
-    }
-    this.getUIContext().getRouter().pushUrl({ url: route }).catch((err: Error) => {
-      console.error(`[CoreManagerPage] pushUrl ${route} failed: ${err.message}`)
+    this.getUIContext().getRouter().replaceUrl({ url: route }).catch((err: Error) => {
+      console.error(`[CoreManagerPage] replaceUrl ${route} failed: ${err.message}`)
     })
   }
 
   @Builder
   private MemoryFootprint() {
     Row({ space: 1 }) {
-      this.FootprintCell('CORE CATALOG', `${this.coreItems.length}`, 72)
-      this.FootprintCell('FIRMWARE SOURCE', '本地', 44)
-      this.FootprintCell('NETWORK UPDATE', '已关闭', 18)
+      this.FootprintCell('LOCAL CORE', `${this.coreItems.length} 项`, 72)
+      this.FootprintCell('FIRMWARE', this.firmwareSummaryText, 44)
+      this.FootprintCell('REMOTE UPDATE', '未配置', 18)
     }
     .width('100%')
     .backgroundColor('#33484848')
@@ -202,6 +243,11 @@ struct CoreManagerPage {
                     .fontColor(EmuColors.onSurfaceVariant)
           .maxLines(1)
           .textOverflow({ overflow: TextOverflow.Ellipsis })
+        Text(item.firmwareDetail)
+          .fontSize(9)
+          .fontColor(EmuColors.onSurfaceVariant)
+          .maxLines(2)
+          .textOverflow({ overflow: TextOverflow.Ellipsis })
       }
       .layoutWeight(1)
       .alignItems(HorizontalAlign.Start)
@@ -214,9 +260,9 @@ struct CoreManagerPage {
           .padding({ left: 8, right: 8, top: 5, bottom: 5 })
           .border({ width: 0.5, color: item.installed ? EmuColors.primary : EmuColors.error, style: BorderStyle.Solid })
 
-        Text('REMOTE_DISABLED')
+        Text(item.firmwareStatus)
           .fontSize(9)
-                    .fontColor(EmuColors.onSurfaceVariant)
+          .fontColor(item.hasFirmwareDependencies ? EmuColors.primary : EmuColors.onSurfaceVariant)
           .padding({ left: 8, right: 8, top: 6, bottom: 6 })
           .border({ width: 0.5, color: EmuColors.outlineVariant, style: BorderStyle.Solid })
       }
@@ -234,17 +280,23 @@ struct CoreManagerPage {
   @Builder
   private KernelLog() {
     Column({ space: 6 }) {
-      Text('KERNEL_LOG')
+      Text('运行日志')
         .fontSize(10)
                 .fontColor(EmuColors.onSurfaceVariant)
         .letterSpacing(2)
-      Text('[SYS] Local core scan reads packaged libs only.')
+      Text('[SCAN] 仅扫描 bundleCodeDir/libs 下已打包的 core 文件')
         .fontSize(10)
                 .fontColor(EmuColors.onSurfaceVariant)
-      Text('[FW] Firmware database is not connected. Missing firmware remains UNKNOWN.')
+      Text(`[FW] 本地固件目录: ${this.firmwareDirectoryText}`)
+        .fontSize(10)
+        .fontColor(EmuColors.onSurfaceVariant)
+      Text(`[FW] ${this.firmwareSummaryText}`)
         .fontSize(10)
                 .fontColor(EmuColors.onSurfaceVariant)
-      Text('[NET] Remote updater intentionally disabled in this phase.')
+      Text(`[FW] ${this.firmwareFilesText}`)
+        .fontSize(10)
+        .fontColor(EmuColors.onSurfaceVariant)
+      Text(`[NET] ${this.remoteUpdateText}，在线更新与固件库下载入口当前不可用`)
         .fontSize(10)
                 .fontColor(EmuColors.primary)
     }
@@ -257,7 +309,7 @@ struct CoreManagerPage {
   build() {
     Column() {
       EmuHeaderBar({
-        titleText: 'OS_EMU_v2.4.1',
+        titleText: '碳影',
         titleIcon: 'terminal',
         rightLabel: '内核与固件管理',
         rightIcon: 'settings_input_component',
@@ -269,7 +321,7 @@ struct CoreManagerPage {
       Scroll() {
         Column({ space: 24 }) {
           Row() {
-            Text('MEMORY_FOOTPRINT')
+            Text('内存占用')
               .fontSize(10)
                             .fontColor(EmuColors.onSurfaceVariant)
               .letterSpacing(2)
@@ -282,10 +334,15 @@ struct CoreManagerPage {
 
           this.MemoryFootprint()
 
-          Text('ACTIVE_CORES')
+          Text('已识别核心')
             .fontSize(10)
                         .fontColor(EmuColors.onSurfaceVariant)
             .letterSpacing(2)
+            .width('100%')
+
+          Text('本页只展示本地已打包 core 与 filesDir/system 下的固件依赖状态；远端更新、在线固件库当前未接入。')
+            .fontSize(10)
+            .fontColor(EmuColors.onSurfaceVariant)
             .width('100%')
 
           Column({ space: 1 }) {
@@ -295,6 +352,13 @@ struct CoreManagerPage {
           }
           .width('100%')
           .border({ width: 0.5, color: '#33484848', style: BorderStyle.Solid })
+
+          if (this.selectedCoreId.length > 0) {
+            Text(this.buildSelectedCoreFirmwareText())
+              .fontSize(10)
+              .fontColor(EmuColors.onSurfaceVariant)
+              .width('100%')
+          }
 
           this.KernelLog()
         }
@@ -320,5 +384,16 @@ struct CoreManagerPage {
     .height('100%')
     .backgroundColor(EmuColors.background)
     .expandSafeArea([SafeAreaType.SYSTEM], [SafeAreaEdge.TOP, SafeAreaEdge.BOTTOM])
+  }
+
+  private buildSelectedCoreFirmwareText(): string {
+    const currentItem = this.coreItems.find((item: ManagedCoreItem) => item.id === this.selectedCoreId)
+    if (!currentItem) {
+      return ''
+    }
+    if (!currentItem.hasFirmwareDependencies) {
+      return `${currentItem.name}: 当前未配置额外固件依赖`
+    }
+    return `${currentItem.name}: ${currentItem.firmwareDetail} / ${currentItem.firmwareFoundText} / ${currentItem.firmwareMissingText}`
   }
 }

--- a/entry/src/main/ets/pages/ImportEntryPage.ets
+++ b/entry/src/main/ets/pages/ImportEntryPage.ets
@@ -102,14 +102,8 @@ struct ImportEntryPage {
     if (route.length === 0) {
       return
     }
-    if (key === 'library') {
-      this.getUIContext().getRouter().replaceUrl({ url: route }).catch((err: Error) => {
-        console.error(`[ImportEntryPage] replaceUrl ${route} failed: ${err.message}`)
-      })
-      return
-    }
-    this.getUIContext().getRouter().pushUrl({ url: route }).catch((err: Error) => {
-      console.error(`[ImportEntryPage] pushUrl ${route} failed: ${err.message}`)
+    this.getUIContext().getRouter().replaceUrl({ url: route }).catch((err: Error) => {
+      console.error(`[ImportEntryPage] replaceUrl ${route} failed: ${err.message}`)
     })
   }
 
@@ -208,7 +202,7 @@ struct ImportEntryPage {
   build() {
     Column() {
       EmuHeaderBar({
-        titleText: 'EMU_CORE_v1.0',
+        titleText: '碳影 / Carbon Shade',
         rightLabel: '本地导入',
         titleIcon: 'memory',
         rightIcon: 'settings_input_component',

--- a/entry/src/main/ets/pages/LibraryDetailPage.ets
+++ b/entry/src/main/ets/pages/LibraryDetailPage.ets
@@ -3,7 +3,10 @@ import { createEmuBottomNavItems, EmuBottomNav } from '../components/EmuBottomNa
 import { EmuIcon } from '../components/EmuIcon'
 import { LibraryDetailActionKey, LibraryDetailActionMenu } from '../components/LibraryDetailActionMenu'
 import { LibraryDetailHeroPanel } from '../components/LibraryDetailHeroPanel'
-import { LibraryDetailInfoPanel } from '../components/LibraryDetailInfoPanel'
+import {
+  LibraryDetailInfoPanel,
+  LibraryDetailSummaryCellData
+} from '../components/LibraryDetailInfoPanel'
 import { LibraryLaunchOverlay } from '../components/LibraryLaunchOverlay'
 import { KeyValueSpecItem, KeyValueSpecList } from '../components/KeyValueSpecList'
 import {
@@ -57,6 +60,104 @@ interface LibraryLaunchRouteParams {
   autoStart?: boolean
 }
 
+@Component
+struct AnimatedDetailBody {
+  @Prop coverKey: string = ''
+  @Prop displayTitle: string = ''
+  @Prop localizedTitle: string = ''
+  @Prop coreLabel: string = ''
+  @Prop showExtendedDetails: boolean = false
+  @Prop primaryCells: LibraryDetailSummaryCellData[] = []
+  @Prop extendedCells: LibraryDetailSummaryCellData[] = []
+  @Prop hasRuntimeSnapshot: boolean = false
+  @Prop telemetryFpsText: string = ''
+  @Prop telemetryAudioText: string = ''
+  @Prop telemetryDropText: string = ''
+  @Prop telemetryProfile: number[] = []
+  @Prop overviewText: string = ''
+  @Prop runtimeSummaryText: string = ''
+  @Prop coreSpecItems: KeyValueSpecItem[] = []
+  onLaunch?: () => void
+  onQuickAction?: (message: string) => void
+  onToggleDetails?: () => void
+  @State private heroScale: number = 1.04
+  @State private telemetryScanOffset: number = -180
+  @State private telemetryGlowOpacity: number = 0.2
+  private visualTimer: number = -1
+
+  aboutToAppear(): void {
+    if (this.visualTimer !== -1) {
+      return
+    }
+    let frame = 0
+    this.visualTimer = setInterval(() => {
+      frame += 1
+      this.heroScale = 1.08 + Math.sin(frame / 18) * 0.035
+      this.telemetryScanOffset = -180 + (frame % 100) * 5
+      this.telemetryGlowOpacity = 0.14 + (Math.sin(frame / 6) + 1) * 0.1
+    }, 90)
+  }
+
+  aboutToDisappear(): void {
+    if (this.visualTimer !== -1) {
+      clearInterval(this.visualTimer)
+      this.visualTimer = -1
+    }
+  }
+
+  build() {
+    Scroll() {
+      Column({ space: 32 }) {
+        LibraryDetailHeroPanel({
+          coverKey: this.coverKey,
+          heroScale: this.heroScale,
+          displayTitle: this.displayTitle,
+          localizedTitle: this.localizedTitle,
+          coreLabel: this.coreLabel,
+          onLaunch: () => {
+            if (this.onLaunch) {
+              this.onLaunch()
+            }
+          },
+          onQuickAction: (message: string) => {
+            if (this.onQuickAction) {
+              this.onQuickAction(message)
+            }
+          }
+        })
+        LibraryDetailInfoPanel({
+          showExtendedDetails: this.showExtendedDetails,
+          primaryCells: this.primaryCells,
+          extendedCells: this.extendedCells,
+          hasRuntimeSnapshot: this.hasRuntimeSnapshot,
+          telemetryFpsText: this.telemetryFpsText,
+          telemetryAudioText: this.telemetryAudioText,
+          telemetryDropText: this.telemetryDropText,
+          telemetryProfile: this.telemetryProfile,
+          telemetryScanOffset: this.telemetryScanOffset,
+          telemetryGlowOpacity: this.telemetryGlowOpacity,
+          overviewText: this.overviewText,
+          runtimeSummaryText: this.runtimeSummaryText,
+          onToggleDetails: () => {
+            if (this.onToggleDetails) {
+              this.onToggleDetails()
+            }
+          }
+        })
+        KeyValueSpecList({
+          title: 'CORE SPECIFICATIONS',
+          items: this.coreSpecItems
+        })
+      }
+      .width('100%')
+      .padding({ left: 24, right: 24, top: 26, bottom: 42 })
+    }
+    .width('100%')
+    .constraintSize({ maxWidth: 390 })
+    .scrollBar(BarState.Off)
+  }
+}
+
 @Entry
 @Component
 struct LibraryDetailPage {
@@ -69,20 +170,20 @@ struct LibraryDetailPage {
   @State private isLaunching: boolean = false
   @State private launchProgress: number = 0
   @State private launchStatusText: string = 'READY_TO_HANDOFF'
-  @State private heroScale: number = 1.04
-  @State private telemetryScanOffset: number = -180
-  @State private telemetryGlowOpacity: number = 0.2
   private readonly coverCycleKeys: string[] = ['', 'metroid_fusion', 'zelda_triforce']
   private readonly coverPalette: string[] = ['#274530', '#27405E', '#4E2A41', '#5A4331']
+  private readonly navItems = createEmuBottomNavItems('library')
   private toastTimer: number = -1
-  private visualTimer: number = -1
   private pageActive: boolean = false
   private pageTaskToken: number = 0
+  private cachedSnapshot: LibraryDetailTelemetrySnapshot | undefined = undefined
+  private cachedSnapshotRomFile: string = ''
+  private cachedCoreSpecItems: KeyValueSpecItem[] = []
+  private cachedCoreSpecRomFile: string = ''
 
   aboutToAppear(): void {
     this.pageActive = true
     void this.loadRecord()
-    this.startVisualLoop()
   }
 
   aboutToDisappear(): void {
@@ -92,7 +193,13 @@ struct LibraryDetailPage {
       clearTimeout(this.toastTimer)
       this.toastTimer = -1
     }
-    this.stopVisualLoop()
+  }
+
+  private invalidateDerivedCaches(): void {
+    this.cachedSnapshot = undefined
+    this.cachedSnapshotRomFile = ''
+    this.cachedCoreSpecItems = []
+    this.cachedCoreSpecRomFile = ''
   }
 
   private beginPageTask(): number {
@@ -130,6 +237,7 @@ struct LibraryDetailPage {
     }
     this.libraryRecord = record
     this.metadataRecord = metadata
+    this.invalidateDerivedCaches()
     this.applyTelemetrySnapshot(record)
   }
 
@@ -160,41 +268,28 @@ struct LibraryDetailPage {
   private applyTelemetrySnapshot(_record: LibraryRecord): void {
   }
 
-  private startVisualLoop(): void {
-    if (this.visualTimer !== -1) {
-      return
+  private getSnapshot(): LibraryDetailTelemetrySnapshot {
+    const romFile = this.libraryRecord?.romFile ?? ''
+    if (romFile.length > 0 && romFile === this.cachedSnapshotRomFile && this.cachedSnapshot) {
+      return this.cachedSnapshot
     }
-    let frame = 0
-    this.visualTimer = setInterval(() => {
-      frame += 1
-      this.heroScale = 1.08 + Math.sin(frame / 18) * 0.035
-      this.telemetryScanOffset = -180 + (frame % 100) * 5
-      this.telemetryGlowOpacity = 0.14 + (Math.sin(frame / 6) + 1) * 0.1
-    }, 90)
-  }
-
-  private stopVisualLoop(): void {
-    if (this.visualTimer !== -1) {
-      clearInterval(this.visualTimer)
-      this.visualTimer = -1
-    }
+    const snapshot = buildLibraryDetailTelemetrySnapshot(this.libraryRecord as LibraryRecord)
+    this.cachedSnapshot = snapshot
+    this.cachedSnapshotRomFile = romFile
+    return snapshot
   }
 
   private get launchCpuText(): string {
-    const snapshot = buildLibraryDetailTelemetrySnapshot(this.libraryRecord as LibraryRecord)
-    return `FPS: ${snapshot.fpsText}`
+    return `FPS: ${this.getSnapshot().fpsText}`
   }
   private get telemetryFpsText(): string {
-    const snapshot = buildLibraryDetailTelemetrySnapshot(this.libraryRecord as LibraryRecord)
-    return snapshot.fpsText
+    return this.getSnapshot().fpsText
   }
   private get telemetryCpuText(): string {
-    const snapshot = buildLibraryDetailTelemetrySnapshot(this.libraryRecord as LibraryRecord)
-    return snapshot.audioText
+    return this.getSnapshot().audioText
   }
   private get telemetryGpuText(): string {
-    const snapshot = buildLibraryDetailTelemetrySnapshot(this.libraryRecord as LibraryRecord)
-    return snapshot.dropText
+    return this.getSnapshot().dropText
   }
 
   private async beginLaunchSequence(record: LibraryRecord): Promise<void> {
@@ -283,6 +378,7 @@ struct LibraryDetailPage {
       return
     }
     this.libraryRecord = updated
+    this.invalidateDerivedCaches()
     this.applyTelemetrySnapshot(updated)
     this.showActionMenu = false
     this.showToastMessage('已切换内置封面 COVER_UPDATED')
@@ -401,11 +497,10 @@ struct LibraryDetailPage {
           iconSize: 15
         })
 
-        Text('EMU_OS // 0.1')
-          .fontFamily('monospace')
+        Text('碳影 / Carbon Shade')
           .fontSize(13)
           .fontColor(EmuColors.primary)
-          .letterSpacing(2.2)
+          .letterSpacing(1.2)
       }
 
       Blank()
@@ -472,11 +567,63 @@ struct LibraryDetailPage {
   }
 
   private getCoreSpecItems(record: LibraryRecord): KeyValueSpecItem[] {
-    return [
+    if (record.romFile === this.cachedCoreSpecRomFile && this.cachedCoreSpecItems.length > 0) {
+      return this.cachedCoreSpecItems
+    }
+    this.cachedCoreSpecItems = [
       { label: 'ROM Version', value: getLibraryDetailRomVersionLabel(record, this.metadataRecord) },
       { label: 'Processor Cluster', value: getLibraryDetailEngineLabel(record) },
       { label: 'Memory Mode', value: getLibraryDetailMemoryModeLabel(record) }
     ]
+    this.cachedCoreSpecRomFile = record.romFile
+    return this.cachedCoreSpecItems
+  }
+
+  private buildPrimaryCells(record: LibraryRecord): LibraryDetailSummaryCellData[] {
+    return [
+      { title: 'CN NAME', value: getLibraryDetailLocalizedTitle(record) },
+      { title: 'YEAR', value: getLibraryDetailYearLabel(record, this.metadataRecord) },
+      { title: 'CONSOLE', value: getLibraryDetailConsoleLabel(record, this.metadataRecord) }
+    ]
+  }
+
+  private buildExtendedCells(record: LibraryRecord): LibraryDetailSummaryCellData[] {
+    return [
+      { title: 'PUBLISHER', value: getLibraryDetailPublisherLabel(this.metadataRecord) },
+      { title: 'PLAYTIME', value: getLibraryDetailPlaytimeLabel(record) },
+      { title: 'ENGINE', value: getLibraryDetailEngineLabel(record) },
+      { title: 'REGION', value: getLibraryDetailRegionLabel(record) }
+    ]
+  }
+
+  @Builder
+  private DetailContent(record: LibraryRecord) {
+    AnimatedDetailBody({
+      coverKey: record.coverKey,
+      displayTitle: getLibraryDetailDisplayTitle(record, this.metadataRecord),
+      localizedTitle: getLibraryDetailLocalizedTitle(record),
+      coreLabel: record.preferredCoreId.toUpperCase(),
+      showExtendedDetails: this.showExtendedDetails,
+      primaryCells: this.buildPrimaryCells(record),
+      extendedCells: this.buildExtendedCells(record),
+      hasRuntimeSnapshot: hasLibraryDetailRuntimeSnapshot(record),
+      telemetryFpsText: this.telemetryFpsText,
+      telemetryAudioText: this.telemetryCpuText,
+      telemetryDropText: this.telemetryGpuText,
+      telemetryProfile: this.getSnapshot().profile,
+      overviewText: getLibraryDetailOverviewText(this.metadataRecord),
+      runtimeSummaryText: getLibraryDetailRuntimeSummaryText(record, this.metadataRecord),
+      coreSpecItems: this.getCoreSpecItems(record),
+      onLaunch: () => {
+        this.beginLaunchSequence(record)
+      },
+      onQuickAction: (message: string) => {
+        this.showToastMessage(message)
+      },
+      onToggleDetails: () => {
+        this.showExtendedDetails = !this.showExtendedDetails
+      }
+    })
   }
 
   private getLocalStatusText(): string {
@@ -559,58 +706,7 @@ struct LibraryDetailPage {
 
         Row() {
           if (this.libraryRecord) {
-            Scroll() {
-              Column({ space: 32 }) {
-                LibraryDetailHeroPanel({
-                  coverKey: (this.libraryRecord as LibraryRecord).coverKey,
-                  heroScale: this.heroScale,
-                  displayTitle: getLibraryDetailDisplayTitle(this.libraryRecord as LibraryRecord, this.metadataRecord),
-                  localizedTitle: getLibraryDetailLocalizedTitle(this.libraryRecord as LibraryRecord),
-                  coreLabel: (this.libraryRecord as LibraryRecord).preferredCoreId.toUpperCase(),
-                  onLaunch: () => {
-                    this.beginLaunchSequence(this.libraryRecord as LibraryRecord)
-                  },
-                  onQuickAction: (message: string) => {
-                    this.showToastMessage(message)
-                  }
-                })
-                LibraryDetailInfoPanel({
-                  showExtendedDetails: this.showExtendedDetails,
-                  primaryCells: [
-                    { title: 'CN NAME', value: getLibraryDetailLocalizedTitle(this.libraryRecord as LibraryRecord) },
-                    { title: 'YEAR', value: getLibraryDetailYearLabel(this.libraryRecord as LibraryRecord, this.metadataRecord) },
-                    { title: 'CONSOLE', value: getLibraryDetailConsoleLabel(this.libraryRecord as LibraryRecord, this.metadataRecord) }
-                  ],
-                  extendedCells: [
-                    { title: 'PUBLISHER', value: getLibraryDetailPublisherLabel(this.metadataRecord) },
-                    { title: 'PLAYTIME', value: getLibraryDetailPlaytimeLabel(this.libraryRecord as LibraryRecord) },
-                    { title: 'ENGINE', value: getLibraryDetailEngineLabel(this.libraryRecord as LibraryRecord) },
-                    { title: 'REGION', value: getLibraryDetailRegionLabel(this.libraryRecord as LibraryRecord) }
-                  ],
-                  hasRuntimeSnapshot: hasLibraryDetailRuntimeSnapshot(this.libraryRecord as LibraryRecord),
-                  telemetryFpsText: this.telemetryFpsText,
-                  telemetryAudioText: this.telemetryCpuText,
-                  telemetryDropText: this.telemetryGpuText,
-                  telemetryProfile: buildLibraryDetailTelemetrySnapshot(this.libraryRecord as LibraryRecord).profile,
-                  telemetryScanOffset: this.telemetryScanOffset,
-                  telemetryGlowOpacity: this.telemetryGlowOpacity,
-                  overviewText: getLibraryDetailOverviewText(this.metadataRecord),
-                  runtimeSummaryText: getLibraryDetailRuntimeSummaryText(this.libraryRecord as LibraryRecord, this.metadataRecord),
-                  onToggleDetails: () => {
-                    this.showExtendedDetails = !this.showExtendedDetails
-                  }
-                })
-                KeyValueSpecList({
-                  title: 'CORE SPECIFICATIONS',
-                  items: this.getCoreSpecItems(this.libraryRecord as LibraryRecord)
-                })
-              }
-              .width('100%')
-              .padding({ left: 24, right: 24, top: 26, bottom: 42 })
-            }
-            .width('100%')
-            .constraintSize({ maxWidth: 390 })
-            .scrollBar(BarState.Off)
+            this.DetailContent(this.libraryRecord as LibraryRecord)
           } else {
             Column() {
               this.EmptyState()
@@ -624,7 +720,7 @@ struct LibraryDetailPage {
         .justifyContent(FlexAlign.Center)
 
         EmuBottomNav({
-          items: createEmuBottomNavItems('library'),
+          items: this.navItems,
           activeFontColor: EmuColors.primary,
           inactiveFontColor: '#665E5E67',
           indicatorStyle: 'dot',

--- a/entry/src/main/ets/pages/LibraryPage.ets
+++ b/entry/src/main/ets/pages/LibraryPage.ets
@@ -122,6 +122,7 @@ struct LibraryPage {
   private pageActionToken: number = 0
   private readonly coverCycleKeys: string[] = ['', 'metroid_fusion', 'zelda_triforce']
   private readonly coverPalette: string[] = ['#274530', '#27405E', '#4E2A41', '#5A4331']
+  private readonly navItems = createEmuBottomNavItems('library')
   private pullTracking: boolean = false
   private pullStartY: number = 0
   private scrollOffsetY: number = 0
@@ -129,6 +130,10 @@ struct LibraryPage {
   private cardTouchStartY: number = 0
   private cardTouchMoved: boolean = false
   private cardLongPressed: boolean = false
+  private cachedFilteredGames: LibraryRecord[] = []
+  private cachedFilteredRecentGames: LibraryRecord[] = []
+  private cachedSearchResults: LibraryRecord[] = []
+  private cachedDisplayPlatformFilters: string[] = []
   aboutToAppear(): void {
     this.pageActive = true
     void this.refreshLibraryGames()
@@ -168,15 +173,22 @@ struct LibraryPage {
   }
 
   private get filteredGames(): LibraryRecord[] {
-    return filterLibraryGames(this.allGames, this.selectedPlatform, this.searchKeyword)
+    return this.cachedFilteredGames
   }
 
   private get filteredRecentGames(): LibraryRecord[] {
-    return filterRecentLibraryGames(this.allGames, this.selectedPlatform, this.searchKeyword)
+    return this.cachedFilteredRecentGames
   }
 
   private get searchResults(): LibraryRecord[] {
-    return buildLibrarySearchResults(this.allGames, this.selectedPlatform, this.searchKeyword)
+    return this.cachedSearchResults
+  }
+
+  private recomputeFilteredCaches(): void {
+    this.cachedFilteredGames = filterLibraryGames(this.allGames, this.selectedPlatform, this.searchKeyword)
+    this.cachedFilteredRecentGames = filterRecentLibraryGames(this.allGames, this.selectedPlatform, this.searchKeyword)
+    this.cachedSearchResults = buildLibrarySearchResults(this.allGames, this.selectedPlatform, this.searchKeyword)
+    this.cachedDisplayPlatformFilters = buildDisplayPlatformFilters(this.allGames)
   }
 
   private clearSearchTimer(): void {
@@ -262,14 +274,16 @@ struct LibraryPage {
     if (this.selectedPlatform !== 'ALL' && !platforms.includes(this.selectedPlatform)) {
       this.selectedPlatform = 'ALL'
     }
+    this.recomputeFilteredCaches()
   }
 
   private getDisplayPlatformFilters(): string[] {
-    return buildDisplayPlatformFilters(this.allGames)
+    return this.cachedDisplayPlatformFilters
   }
 
   private onSearchKeywordChange(value: string): void {
     this.searchKeyword = value
+    this.recomputeFilteredCaches()
     const trimmed = value.trim()
     this.clearSearchTimer()
     if (trimmed.length === 0) {
@@ -435,19 +449,40 @@ struct LibraryPage {
           }, 1200)
   }
 
+  private suspendBeforeRoute(): void {
+    this.pageActive = false
+    this.libraryRefreshToken += 1
+    this.pageActionToken += 1
+    this.clearSearchTimer()
+    this.clearLongPressTimer()
+    if (this.toastTimer !== -1) {
+      clearTimeout(this.toastTimer)
+      this.toastTimer = -1
+    }
+    if (this.refreshTimer !== -1) {
+      clearTimeout(this.refreshTimer)
+      this.refreshTimer = -1
+    }
+    if (this.bottomLoaderTimer !== -1) {
+      clearTimeout(this.bottomLoaderTimer)
+      this.bottomLoaderTimer = -1
+    }
+    this.searchBusy = false
+    this.refreshing = false
+    this.bottomLoaderActive = false
+    this.showSearchResults = false
+    this.pullRefreshHeight = 0
+    this.pullRefreshOpacity = 0
+  }
+
   private onBottomNavClick(key: string): void {
     const route = getEmuBottomNavTargetRoute(key, 'library')
     if (route.length === 0) {
       return
     }
-    if (key === 'library') {
-      this.getUIContext().getRouter().replaceUrl({ url: route }).catch((err: Error) => {
-        console.error(`[LibraryPage] replaceUrl ${route} failed: ${err.message}`)
-      })
-      return
-    }
-    this.getUIContext().getRouter().pushUrl({ url: route }).catch((err: Error) => {
-      console.error(`[LibraryPage] pushUrl ${route} failed: ${err.message}`)
+    this.suspendBeforeRoute()
+    this.getUIContext().getRouter().replaceUrl({ url: route }).catch((err: Error) => {
+      console.error(`[LibraryPage] replaceUrl ${route} failed: ${err.message}`)
     })
   }
 
@@ -688,11 +723,13 @@ struct LibraryPage {
       },
       onSearchResultLaunch: (item: LibraryRecord) => {
         this.searchKeyword = item.title
+        this.recomputeFilteredCaches()
         this.hideSearchResults()
         this.openGame(item)
       },
       onPlatformChange: (value: string) => {
         this.selectedPlatform = value
+        this.recomputeFilteredCaches()
       }
     })
   }
@@ -767,7 +804,7 @@ struct LibraryPage {
     Stack() {
       Column() {
         EmuHeaderBar({
-          titleText: 'EMU_OS // 0.1',
+          titleText: '碳影 / Carbon Shade',
           titleIcon: 'terminal',
           rightIcon: 'settings_input_component',
           activeTextColor: EmuColors.primary,
@@ -788,7 +825,7 @@ struct LibraryPage {
         .justifyContent(FlexAlign.Center)
 
         EmuBottomNav({
-          items: createEmuBottomNavItems('library'),
+          items: this.navItems,
           activeFontColor: EmuColors.primary,
           inactiveFontColor: '#FF666666',
           indicatorStyle: 'dot',

--- a/entry/src/main/ets/pages/LibretroGamePage.ets
+++ b/entry/src/main/ets/pages/LibretroGamePage.ets
@@ -67,6 +67,12 @@ import { RuntimeLibrarySessionTracker } from '../common/RuntimeLibrarySessionTra
 import { RuntimeSaveStateController } from '../common/RuntimeSaveStateController'
 import { runtimeSessionController } from '../common/RuntimeSessionController'
 import {
+  createDefaultRuntimeRenderSettingsProfile,
+  loadRuntimeRenderSettingsProfile,
+  RuntimeRenderSettingsProfile,
+  saveRuntimeRenderSettingsProfile
+} from '../common/RuntimeRenderSettingsRepository'
+import {
   RuntimeSoakState,
   RuntimeSoakTestController
 } from '../common/RuntimeSoakTestController'
@@ -147,6 +153,7 @@ struct LibretroGamePage {
   private readonly inputDebugTracker: RuntimeInputDebugTracker = new RuntimeInputDebugTracker();
   private readonly runtimeSaveStateController: RuntimeSaveStateController = new RuntimeSaveStateController();
   private readonly soakController: RuntimeSoakTestController = new RuntimeSoakTestController();
+  private renderSettingsProfile: RuntimeRenderSettingsProfile = createDefaultRuntimeRenderSettingsProfile();
   private readonly startOrSwitchDebounceMs: number = 600;
   private readonly runtimeInputLayoutWidth: number = 440;
   private readonly runtimeInputLayoutHeight: number = 340;
@@ -199,6 +206,7 @@ struct LibretroGamePage {
     this.refreshInputDevices();
     this.syncPortAssignments();
     void this.loadRuntimeInputLayout();
+    void this.loadRuntimeRenderSettings();
     this.refreshHudMetricsCache();
   }
   
@@ -239,6 +247,33 @@ struct LibretroGamePage {
       LogHelper.warn('LibretroGame', 'Input', `读取本地输入布局失败: ${message}`);
       this.runtimeInputLayoutButtons = createDefaultInputLayoutProfile().buttons;
     }
+  }
+
+  private async loadRuntimeRenderSettings(): Promise<void> {
+    const context = this.getUIContext().getHostContext() as common.UIAbilityContext;
+    if (!context) {
+      return;
+    }
+    const profile = await loadRuntimeRenderSettingsProfile(context);
+    this.renderSettingsProfile = profile;
+    this.scalingMode = profile.scalingMode;
+    this.softwareMaxPresetIndex = profile.softwareMaxPresetIndex;
+    this.hwRenderAllowed = profile.hwRenderAllowed;
+  }
+
+  private async persistRuntimeRenderSettingsProfile(): Promise<void> {
+    const context = this.getUIContext().getHostContext() as common.UIAbilityContext;
+    if (!context) {
+      return;
+    }
+    this.renderSettingsProfile = {
+      version: this.renderSettingsProfile.version,
+      scalingMode: this.scalingMode,
+      softwareMaxPresetIndex: this.softwareMaxPresetIndex,
+      hwRenderAllowed: this.hwRenderAllowed,
+      updatedAt: this.renderSettingsProfile.updatedAt
+    };
+    this.renderSettingsProfile = await saveRuntimeRenderSettingsProfile(context, this.renderSettingsProfile);
   }
 
   private getCurrentRuntimeRomFile(): string {
@@ -738,6 +773,7 @@ struct LibretroGamePage {
     const preset = presets[index] || presets[1];
     const okMax = runtimeRenderSettingsController.setSoftwareMaxResolution(preset.w, preset.h);
     this.clearRuntimeStatsForConfigChange();
+    void this.persistRuntimeRenderSettingsProfile();
     LogHelper.info('LibretroGame', 'Config', `设置软件最大分辨率: ${preset.w}x${preset.h}, okMax=${okMax}`);
   }
 
@@ -755,6 +791,7 @@ struct LibretroGamePage {
       runtimeRenderSettingsController.setSoftwareMaxResolution(preset.w, preset.h);
     }
     this.clearRuntimeStatsForConfigChange();
+    void this.persistRuntimeRenderSettingsProfile();
     LogHelper.info('LibretroGame', 'Config', `设置缩放模式: ${index}, okMode=${okMode}`);
   }
 
@@ -991,6 +1028,7 @@ struct LibretroGamePage {
         onHwRenderChange: (value: boolean) => {
           this.hwRenderAllowed = value;
           const ok = runtimeRenderSettingsController.setHwRenderAllowed(value);
+          void this.persistRuntimeRenderSettingsProfile();
           LogHelper.info('LibretroGame', 'Config', `设置 HW_RENDER 允许: ${value}, ok=${ok}`);
         },
         onHideVirtualControllerChange: (value: boolean) => {

--- a/entry/src/main/ets/pages/MetadataEditPage.ets
+++ b/entry/src/main/ets/pages/MetadataEditPage.ets
@@ -208,7 +208,7 @@ struct MetadataEditPage {
   build() {
     Column() {
       EmuHeaderBar({
-        titleText: 'EMU_CORE_v1.0',
+        titleText: '碳影 / Carbon Shade',
         titleIcon: 'memory',
         rightLabel: this.statusText,
         rightIcon: 'settings_input_component',

--- a/entry/src/main/ets/pages/MultiplayerInputPage.ets
+++ b/entry/src/main/ets/pages/MultiplayerInputPage.ets
@@ -1,12 +1,9 @@
-import { EmuHeaderBar, EmuPrecisionGridBackdrop } from '../components/EmuAppShell'
+import { BarChartBackground, BarChartItem, EmuHeaderBar, EmuPrecisionGridBackdrop } from '../components/EmuAppShell'
 import { createEmuBottomNavItems, EmuBottomNav } from '../components/EmuBottomNav'
 import { EmuIcon } from '../components/EmuIcon'
 import { EmuColors } from '../common/EmuUiTokens'
 import { getEmuBottomNavTargetRoute } from '../common/RouteHelper'
-import {
-  InputDeviceInfo,
-  InputSourceType
-} from '../common/InputPortRouting'
+import { InputDeviceInfo } from '../common/InputPortRouting'
 import { runtimeInputPortController } from '../common/RuntimeInputPortController'
 
 interface ControllerSlotItem {
@@ -40,95 +37,72 @@ interface InputLogItem {
   isPrimary: boolean
 }
 
-interface TelemetryBarItem {
-  id: string
-  height: number
-  isPrimary: boolean
-}
 
 @Entry
 @Component
 struct MultiplayerInputPage {
-  @State private deviceNamesText: string = 'NO_EXTERNAL_DEVICE'
+  @State private deviceNamesText: string = ''
   @State private deviceCountText: string = '0'
   @State private selectedRoomId: string = 'local'
-  @State private localLatencyText: string = 'FRAME_SYNC'
+  @State private localLatencyText: string = '本地触控'
+  @State private inputLogTitleText: string = '等待输入'
+  @State private inputLogDetailText: string = '刷新设备后可查看当前外接手柄状态'
+  private readonly navItems = createEmuBottomNavItems('input')
 
-  private readonly telemetryBars: TelemetryBarItem[] = [
-    { id: 'j-01', height: 24, isPrimary: false },
-    { id: 'j-02', height: 30, isPrimary: false },
-    { id: 'j-03', height: 18, isPrimary: true },
-    { id: 'j-04', height: 22, isPrimary: true },
-    { id: 'j-05', height: 26, isPrimary: true },
-    { id: 'j-06', height: 44, isPrimary: false },
-    { id: 'j-07', height: 16, isPrimary: true },
-    { id: 'j-08', height: 20, isPrimary: true },
-    { id: 'j-09', height: 34, isPrimary: false },
-    { id: 'j-10', height: 14, isPrimary: true },
-    { id: 'j-11', height: 18, isPrimary: true },
-    { id: 'j-12', height: 20, isPrimary: true },
-    { id: 'j-13', height: 28, isPrimary: false },
-    { id: 'j-14', height: 23, isPrimary: true },
-    { id: 'j-15', height: 17, isPrimary: true },
-    { id: 'j-16', height: 21, isPrimary: true },
-    { id: 'j-17', height: 24, isPrimary: false },
-    { id: 'j-18', height: 22, isPrimary: true },
-    { id: 'j-19', height: 30, isPrimary: false },
-    { id: 'j-20', height: 16, isPrimary: true },
-    { id: 'j-21', height: 14, isPrimary: true },
-    { id: 'j-22', height: 20, isPrimary: true },
-    { id: 'j-23', height: 40, isPrimary: false },
-    { id: 'j-24', height: 18, isPrimary: true }
+  private readonly lobbyRooms: LobbyRoomItem[] = [
+    {
+      id: 'local',
+      title: '本地游玩',
+      game: '当前运行输入桥',
+      latency: '0ms',
+      players: '1 / 1',
+      status: 'READY',
+      color: EmuColors.primary
+    },
+    {
+      id: 'adapter',
+      title: 'Netplay 联机',
+      game: '中继 / 房间服务未配置',
+      latency: '--',
+      players: 'OFFLINE',
+      status: '未配置',
+      color: EmuColors.error
+    },
+    {
+      id: 'layout',
+      title: '按键布局编辑',
+      game: '触控按键与热区校准',
+      latency: '本地',
+      players: 'P1',
+      status: '可编辑',
+      color: EmuColors.secondary
+    }
+  ]
+  @State private controllerSlots: ControllerSlotItem[] = []
+
+  private readonly telemetryBars: BarChartItem[] = [
+    { height: 24, isPrimary: false }, { height: 30, isPrimary: false },
+    { height: 18, isPrimary: true },  { height: 22, isPrimary: true },
+    { height: 26, isPrimary: true },  { height: 44, isPrimary: false },
+    { height: 16, isPrimary: true },  { height: 20, isPrimary: true },
+    { height: 34, isPrimary: false }, { height: 14, isPrimary: true },
+    { height: 18, isPrimary: true },  { height: 20, isPrimary: true },
+    { height: 28, isPrimary: false }, { height: 23, isPrimary: true },
+    { height: 17, isPrimary: true },  { height: 21, isPrimary: true },
+    { height: 24, isPrimary: false }, { height: 22, isPrimary: true },
+    { height: 30, isPrimary: false }, { height: 16, isPrimary: true },
+    { height: 14, isPrimary: true },  { height: 20, isPrimary: true },
+    { height: 40, isPrimary: false }, { height: 18, isPrimary: true }
   ]
 
-  private readonly inputLogs: InputLogItem[] = [
-    { id: 'l-01', time: '[00:48:12]', eventName: 'P1_BTN_A', state: 'PRESS', isPrimary: true },
-    { id: 'l-02', time: '[00:48:12]', eventName: 'P1_DIR_RT', state: 'HOLD', isPrimary: false },
-    { id: 'l-03', time: '[00:48:13]', eventName: 'P1_BTN_A', state: 'RELEASE', isPrimary: false },
-    { id: 'l-04', time: '[00:48:14]', eventName: 'P2_BTN_ST', state: 'WAIT', isPrimary: false },
-    { id: 'l-05', time: '[00:48:14]', eventName: 'P1_DIR_UP', state: 'PRESS', isPrimary: true },
-    { id: 'l-06', time: '[00:48:15]', eventName: 'P1_BTN_B', state: 'PRESS', isPrimary: true }
-  ]
+  @State private inputLogs: InputLogItem[] = []
 
   aboutToAppear(): void {
-    this.refreshInputDevices()
+    this.refreshDevices()
   }
 
-  private refreshInputDevices(): void {
-    const devices: InputDeviceInfo[] = runtimeInputPortController.listInputDevices()
-    this.deviceCountText = `${devices.length}`
-    this.deviceNamesText = this.buildDeviceNamesText(devices)
-    this.localLatencyText = devices.length > 0 ? 'INPUT_QUEUE' : 'FRAME_SYNC'
-  }
-
-  private buildDeviceNamesText(devices: InputDeviceInfo[]): string {
-    if (devices.length === 0) {
-      return 'NO_EXTERNAL_DEVICE'
-    }
-    const names: string[] = []
-    devices.forEach((device: InputDeviceInfo) => {
-      names.push(this.buildDeviceLabel(device))
-    })
-    return names.join(' / ')
-  }
-
-  private buildDeviceLabel(device: InputDeviceInfo): string {
-    if (device.sourceType === InputSourceType.Keyboard) {
-      return `KEYBOARD:${device.name}`
-    }
-    if (device.sourceType === InputSourceType.Mouse) {
-      return `MOUSE:${device.name}`
-    }
-    if (device.sourceType === InputSourceType.Gamepad) {
-      return `GAMEPAD:${device.name}`
-    }
-    if (device.sourceType === InputSourceType.BluetoothGamepad) {
-      return `BT_PAD:${device.name}`
-    }
-    return device.name.length > 0 ? device.name : device.deviceId
-  }
-
-  private getControllerSlots(): ControllerSlotItem[] {
+  private buildControllerSlots(): ControllerSlotItem[] {
+    const hasExternal = this.deviceNamesText.length > 0
     return [
       {
         id: 'p1',
@@ -145,48 +119,52 @@ struct MultiplayerInputPage {
       {
         id: 'p2',
         label: '外接手柄',
-        name: this.deviceNamesText === 'NO_EXTERNAL_DEVICE' ? '等待连接手柄' : this.deviceNamesText,
-        deviceId: this.deviceNamesText === 'NO_EXTERNAL_DEVICE' ? '等待 HID / 蓝牙手柄' : `${this.deviceCountText} 个输入设备`,
-        status: this.deviceNamesText === 'NO_EXTERNAL_DEVICE' ? '未绑定' : '已连接',
-        powerText: this.deviceNamesText === 'NO_EXTERNAL_DEVICE' ? '无设备' : '输入总线',
-        pollingRate: this.deviceNamesText === 'NO_EXTERNAL_DEVICE' ? '--' : 'DEVICE',
-        latency: this.deviceNamesText === 'NO_EXTERNAL_DEVICE' ? '--' : 'NATIVE',
-        protocol: this.deviceNamesText === 'NO_EXTERNAL_DEVICE' ? 'HID_WAIT' : 'HID',
-        isActive: this.deviceNamesText !== 'NO_EXTERNAL_DEVICE'
+        name: hasExternal ? this.deviceNamesText : '等待连接手柄',
+        deviceId: hasExternal ? `${this.deviceCountText} 个输入设备` : '等待 HID / 蓝牙手柄',
+        status: hasExternal ? '已连接' : '未绑定',
+        powerText: hasExternal ? '输入总线' : '无设备',
+        pollingRate: hasExternal ? '设备轮询' : '--',
+        latency: hasExternal ? '系统直连' : '--',
+        protocol: hasExternal ? 'HID' : '等待接入',
+        isActive: hasExternal
       }
     ]
   }
 
-  private getLobbyRooms(): LobbyRoomItem[] {
-    return [
+  private refreshDevices(): void {
+    const devices: InputDeviceInfo[] = runtimeInputPortController.listInputDevices()
+    const names: string[] = []
+    const logs: InputLogItem[] = [
       {
-        id: 'local',
-        title: '本地游玩',
-        game: '当前运行输入桥',
-        latency: '0ms',
-        players: '1 / 1',
-        status: 'READY',
-        color: EmuColors.primary
-      },
-      {
-        id: 'adapter',
-        title: 'Netplay 联机',
-        game: '中继 / 房间服务未配置',
-        latency: '--',
-        players: 'OFFLINE',
-        status: '未配置',
-        color: EmuColors.error
-      },
-      {
-        id: 'layout',
-        title: '按键布局编辑',
-        game: '触控按键与热区校准',
-        latency: '本地',
-        players: 'P1',
-        status: '可编辑',
-        color: EmuColors.secondary
+        id: 'local-touch',
+        time: '[本地]',
+        eventName: '触控布局',
+        state: '就绪',
+        isPrimary: true
       }
     ]
+    devices.forEach((item: InputDeviceInfo, index: number) => {
+      const deviceName = `${item.name}`.trim()
+      if (deviceName.length > 0) {
+        names.push(deviceName)
+      }
+      logs.push({
+        id: `device-${index}`,
+        time: '[设备]',
+        eventName: deviceName.length > 0 ? deviceName : `设备 ${index + 1}`,
+        state: `${item.deviceId}`.trim().length > 0 ? '已识别' : '已连接',
+        isPrimary: true
+      })
+    })
+    this.deviceNamesText = names.join(' / ')
+    this.deviceCountText = `${devices.length}`
+    this.localLatencyText = devices.length > 0 ? '多源输入' : '本地触控'
+    this.controllerSlots = this.buildControllerSlots()
+    this.inputLogs = logs
+    this.inputLogTitleText = devices.length > 0 ? `已识别 ${devices.length} 个外接设备` : '未检测到外接手柄'
+    this.inputLogDetailText = devices.length > 0 ?
+      '当前已读取本机输入设备列表' :
+      '当前仅启用本地触控布局'
   }
 
   private onBottomNavClick(key: string): void {
@@ -194,14 +172,8 @@ struct MultiplayerInputPage {
     if (route.length === 0) {
       return
     }
-    if (key === 'library') {
-      this.getUIContext().getRouter().replaceUrl({ url: route }).catch((err: Error) => {
-        console.error(`[MultiplayerInputPage] replaceUrl ${route} failed: ${err.message}`)
-      })
-      return
-    }
-    this.getUIContext().getRouter().pushUrl({ url: route }).catch((err: Error) => {
-      console.error(`[MultiplayerInputPage] pushUrl ${route} failed: ${err.message}`)
+    this.getUIContext().getRouter().replaceUrl({ url: route }).catch((err: Error) => {
+      console.error(`[MultiplayerInputPage] replaceUrl ${route} failed: ${err.message}`)
     })
   }
 
@@ -345,7 +317,7 @@ struct MultiplayerInputPage {
       .justifyContent(FlexAlign.SpaceBetween)
 
       Column({ space: 1 }) {
-        ForEach(this.getLobbyRooms(), (room: LobbyRoomItem) => {
+        ForEach(this.lobbyRooms, (room: LobbyRoomItem) => {
           this.RoomRow(room)
         }, (room: LobbyRoomItem) => room.id)
       }
@@ -467,19 +439,15 @@ struct MultiplayerInputPage {
         EmuPrecisionGridBackdrop()
           .opacity(0.26)
 
-        Row({ space: 2 }) {
-          ForEach(this.telemetryBars, (item: TelemetryBarItem) => {
-            Row()
-              .layoutWeight(1)
-              .height(item.height)
-              .backgroundColor(item.isPrimary ? EmuColors.primary : EmuColors.surfaceContainerHighest)
-              .opacity(item.isPrimary ? 0.5 : 1)
-          }, (item: TelemetryBarItem) => item.id)
-        }
-        .width('100%')
-        .height('100%')
-        .padding({ left: 10, right: 10, bottom: 10 })
-        .alignItems(VerticalAlign.Bottom)
+        BarChartBackground({
+          bars: this.telemetryBars,
+          primaryColor: EmuColors.primary,
+          secondaryColor: EmuColors.surfaceContainerHighest,
+          barGap: 2
+        })
+          .width('100%')
+          .height('100%')
+          .padding({ left: 10, right: 10, bottom: 10 })
 
         Row()
           .width('100%')
@@ -517,6 +485,16 @@ struct MultiplayerInputPage {
       }
       .alignItems(VerticalAlign.Center)
 
+      Text(this.inputLogTitleText)
+        .fontSize(12)
+        .fontColor(EmuColors.onSurface)
+        .width('100%')
+
+      Text(this.inputLogDetailText)
+        .fontSize(10)
+        .fontColor(EmuColors.onSurfaceVariant)
+        .width('100%')
+
       Column({ space: 6 }) {
         ForEach(this.inputLogs, (item: InputLogItem) => {
           Row() {
@@ -552,7 +530,7 @@ struct MultiplayerInputPage {
         .backgroundColor(EmuColors.surfaceContainerHigh)
         .borderRadius(0)
         .onClick(() => {
-          this.refreshInputDevices()
+          this.refreshDevices()
         })
 
       Button('编辑按键布局')
@@ -573,7 +551,7 @@ struct MultiplayerInputPage {
   build() {
     Column() {
       EmuHeaderBar({
-        titleText: 'OS_EMU_v2.4.1',
+        titleText: '碳影 / Carbon Shade',
         titleIcon: 'terminal',
         rightLabel: '输入映射与联机中心',
         rightIcon: 'settings_input_component',
@@ -588,7 +566,7 @@ struct MultiplayerInputPage {
       Scroll() {
         Column({ space: 22 }) {
           Column({ space: 14 }) {
-            ForEach(this.getControllerSlots(), (item: ControllerSlotItem) => {
+            ForEach(this.controllerSlots, (item: ControllerSlotItem) => {
               this.ControllerCard(item)
             }, (item: ControllerSlotItem) => item.id)
           }
@@ -613,7 +591,7 @@ struct MultiplayerInputPage {
       .scrollBar(BarState.Off)
 
       EmuBottomNav({
-        items: createEmuBottomNavItems('input'),
+        items: this.navItems,
         activeFontColor: EmuColors.primary,
         inactiveFontColor: '#FF666666',
         indicatorStyle: 'line',

--- a/entry/src/main/ets/pages/SaveStatePage.ets
+++ b/entry/src/main/ets/pages/SaveStatePage.ets
@@ -309,11 +309,11 @@ struct SaveStatePage {
           iconSize: 21
         })
 
-        Text('EMU_CORE_v1.0')
+        Text('碳影 / Carbon Shade')
           .fontSize(16)
                     .fontWeight(FontWeight.Bold)
           .fontColor(EmuColors.primary)
-          .letterSpacing(3)
+          .letterSpacing(1.6)
           .maxLines(1)
           .textOverflow({ overflow: TextOverflow.Ellipsis })
       }

--- a/entry/src/main/ets/pages/ShaderPreviewPage.ets
+++ b/entry/src/main/ets/pages/ShaderPreviewPage.ets
@@ -35,6 +35,22 @@ struct ShaderPreviewPage {
     return Math.max(0, Math.min(100, value))
   }
 
+  private clampPercent(value: number): number {
+    return Math.max(0, Math.min(200, Math.round(value)))
+  }
+
+  private onScanlineIntensityChange = (value: number): void => {
+    this.scanlineIntensity = Math.max(0, Math.min(100, Math.round(value)))
+  }
+
+  private onCurvatureChange = (value: number): void => {
+    this.curvature = Math.max(0, Math.min(100, Math.round(value)))
+  }
+
+  private onSaturationChange = (value: number): void => {
+    this.saturation = this.clampPercent(value)
+  }
+
   private onBottomNavClick(key: string): void {
     const route = getEmuBottomNavTargetRoute(key, 'engine')
     if (route.length === 0) {
@@ -119,8 +135,8 @@ struct ShaderPreviewPage {
   private SplitPreview() {
     Stack() {
       Row({ space: 1 }) {
-        this.PreviewPane('SOURCE_RAW', 'NEAREST / NO_SHADER', false)
-        this.PreviewPane('LIVE_SHADER', this.selectedMode, true)
+        this.PreviewPane('原始画面', '原始输出', false)
+        this.PreviewPane('滤镜预览', this.selectedMode, true)
       }
       .width('100%')
       .height('100%')
@@ -161,9 +177,9 @@ struct ShaderPreviewPage {
       .width('100%')
       .justifyContent(FlexAlign.SpaceBetween)
 
-      this.SliderRow('扫描线强度', this.scanlineIntensity, '%')
-      this.SliderRow('CRT 曲率', this.curvature, '%')
-      this.SliderRow('色彩饱和度', this.saturation, '%')
+      this.SliderRow('扫描线强度', this.scanlineIntensity, '%', 0, 100, this.onScanlineIntensityChange)
+      this.SliderRow('CRT 曲率', this.curvature, '%', 0, 100, this.onCurvatureChange)
+      this.SliderRow('色彩饱和度', this.saturation, '%', 0, 200, this.onSaturationChange)
 
       Row({ space: 12 }) {
         Button('重置')
@@ -198,7 +214,14 @@ struct ShaderPreviewPage {
   }
 
   @Builder
-  private SliderRow(label: string, value: number, suffix: string) {
+  private SliderRow(
+    label: string,
+    value: number,
+    suffix: string,
+    min: number,
+    max: number,
+    onChange: (value: number) => void
+  ) {
     Column({ space: 8 }) {
       Row() {
         Text(label)
@@ -212,30 +235,19 @@ struct ShaderPreviewPage {
       .width('100%')
       .justifyContent(FlexAlign.SpaceBetween)
 
-      Stack() {
-        Row()
-          .width('100%')
-          .height(1)
-          .backgroundColor(EmuColors.outlineVariant)
-        Row()
-          .width(`${this.getSliderTrackValue(value)}%`)
-          .height(1)
-          .backgroundColor(EmuColors.primary)
-          .align(Alignment.Start)
-
-        Row() {
-          Row()
-            .width(2)
-            .height(12)
-            .backgroundColor(EmuColors.onSurface)
-        }
-        .width(`${this.getSliderTrackValue(value)}%`)
-        .height(1)
-        .justifyContent(FlexAlign.End)
-        .align(Alignment.Start)
-      }
-      .width('100%')
-      .height(14)
+      Slider({
+        value: value,
+        min: min,
+        max: max,
+        step: 1
+      })
+        .width('100%')
+        .blockColor(EmuColors.onSurface)
+        .trackColor(EmuColors.outlineVariant)
+        .selectedColor(EmuColors.primary)
+        .showSteps(false)
+        .showTips(false)
+        .onChange(onChange)
     }
     .width('100%')
   }
@@ -296,7 +308,7 @@ struct ShaderPreviewPage {
   build() {
     Column() {
       EmuHeaderBar({
-        titleText: 'OS_EMU_v2.4.1',
+        titleText: '碳影',
         titleIcon: 'terminal',
         rightLabel: '滤镜预览',
         rightIcon: 'settings_input_component',


### PR DESCRIPTION
## Summary
继 #57 后的尾巴收口，3 个独立主题 commit 组成：

- **805e0fc** `chore(common)`：7 个 Repository 的 `fs.close/IO` 异常包裹，避免 close 异常覆盖原 IO 错误
- **8fed179** `perf(ui)`：5-21 路由/性能排障结论的代码落地 —— 底部 tab 统一 `replaceUrl`、`suspendBeforeRoute()`、抽 `@Component AnimatedDetailBody` / `BarChartBackground`、`@Prop` 收口、`LibraryPage` 缓存 filter；同时接入 #57 引入的 `CoreFirmwareRepository` / `RuntimeRenderSettingsRepository`
- **28557ba** `docs+ui(copy)`：`AGENTS.md` 沉淀 2 条规则（顶级 tab 用 `replaceUrl`、性能排障不要先入为主怀疑 Canvas），并完成"碳影 / Carbon Shade"品牌名最后两个文件的文案收口

## Background
- 22 个工作区脏改动从 `fix/ci-26208088701` stash 出来，#57 合入 main 后再 pop 到新分支
- 性能排障结论来源：`docs/2026-05-04-next-session-handoff.md` 5-21 章节
- 不主动编译 / 真机 / 跑测试脚本；交给 PR CI 与用户运行验证

## Test plan
- [ ] PR CI（`harmonyos-pr-ci.yml`）通过：hvigor 构建 / codelinter / HAP smoke
- [ ] 用户运行验证：底部 tab 切换钝感是否进一步改善
- [ ] 用户运行验证：LibraryDetailPage 动效流畅度（抽出 AnimatedDetailBody 后）
- [ ] 用户运行验证：ShaderPreviewPage 滑块是否真正生效（之前只读）
- [ ] 用户运行验证：CoreManagerPage 是否正确展示 system/ 目录与 BIOS 依赖

🤖 Generated with [Claude Code](https://claude.com/claude-code)