### PR TITLE
fix(short-term): correctness fixes across audio/napi/plugin/config/build

### DIFF
--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -113,6 +113,14 @@ add_library(entry SHARED
     ${APP_NAPI_SOURCES}
 )
 
+find_library(
+    # Sets the name of the path variable.
+    hilog-lib
+    # Specifies the name of the NDK library that
+    # you want CMake to locate.
+    hilog_ndk.z
+)
+
 # ========== 测试可执行目标 (独立于 libentry.so) ==========
 # 启用方式: cmake -DBUILD_LIBRETRO_TESTS=ON ...
 # 默认 OFF: HAP 构建不引入测试,避免污染发布产物。
@@ -127,13 +135,6 @@ if(BUILD_LIBRETRO_TESTS)
     target_link_libraries(libretro_tests PRIVATE ${hilog-lib} dl)
 endif()
 
-find_library(
-    # Sets the name of the path variable.
-    hilog-lib
-    # Specifies the name of the NDK library that
-    # you want CMake to locate.
-    hilog_ndk.z
-)
 target_link_libraries(entry PUBLIC ${hilog-lib})
 target_link_libraries(entry PUBLIC libace_napi.z.so)
 target_link_libraries(entry PUBLIC libace_ndk.z.so)

--- a/entry/src/main/cpp/CMakeLists.txt
+++ b/entry/src/main/cpp/CMakeLists.txt
@@ -111,11 +111,21 @@ add_library(entry SHARED
     ${PLATFORM_RESOURCE_SOURCES}
     ${APP_FRAMEWORK_SOURCES}
     ${APP_NAPI_SOURCES}
-    # 测试文件已移动到tests/目录，暂时从构建中排除
-    # tests/unit/core_loader_test.cpp
-    # tests/integration/test_gambatte_load.cpp
-    # tests/integration/test_gambatte_rom.cpp
 )
+
+# ========== 测试可执行目标 (独立于 libentry.so) ==========
+# 启用方式: cmake -DBUILD_LIBRETRO_TESTS=ON ...
+# 默认 OFF: HAP 构建不引入测试,避免污染发布产物。
+# CI 应在独立 step 中以 ON 构建并执行 libretro_tests。
+option(BUILD_LIBRETRO_TESTS "Build libretro unit/integration tests" OFF)
+if(BUILD_LIBRETRO_TESTS)
+    add_executable(libretro_tests
+        tests/unit/core_loader_test.cpp
+        tests/integration/test_gambatte_load.cpp
+        tests/integration/test_gambatte_rom.cpp
+    )
+    target_link_libraries(libretro_tests PRIVATE ${hilog-lib} dl)
+endif()
 
 find_library(
     # Sets the name of the path variable.

--- a/entry/src/main/cpp/app/framework/plugin_manager.cpp
+++ b/entry/src/main/cpp/app/framework/plugin_manager.cpp
@@ -387,7 +387,10 @@ PluginManager *PluginManager::GetInstance() {
 
 PluginManager::~PluginManager() {
   LOGF(LOG_INFO, "~PluginManager");
-  nativeXComponentMap_.clear();
+  {
+    std::lock_guard<std::mutex> lock(map_mutex_);
+    nativeXComponentMap_.clear();
+  }
   ClearAllNewArchPointerStates();
 }
 
@@ -704,6 +707,7 @@ void PluginManager::SetNativeXComponent(std::string &id,
     return;
   }
 
+  std::lock_guard<std::mutex> lock(map_mutex_);
   if (nativeXComponentMap_.find(id) == nativeXComponentMap_.end()) {
     nativeXComponentMap_[id] = nativeXComponent;
     return;

--- a/entry/src/main/cpp/app/framework/plugin_manager.h
+++ b/entry/src/main/cpp/app/framework/plugin_manager.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <js_native_api.h>
 #include <js_native_api_types.h>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -45,6 +46,9 @@ public:
   bool GetNewArchInputStats(NewArchInputStats &out) const;
 
 private:
+  // nativeXComponentMap_ 在 napi 调用线程(Export)与 UI 线程(SetNativeXComponent
+  // 经由 Surface 回调)之间共享,必须用 mutex 保护避免哈希表内部状态损坏。
+  mutable std::mutex map_mutex_;
   std::unordered_map<std::string, OH_NativeXComponent *> nativeXComponentMap_;
 };
 #endif // PLUGIN_MANAGER_H

--- a/entry/src/main/cpp/app/napi/engine_napi_common.h
+++ b/entry/src/main/cpp/app/napi/engine_napi_common.h
@@ -41,9 +41,12 @@ inline napi_value MakeBool(napi_env env, bool value) {
 }
 
 inline napi_value MakeResolvedPromise(napi_env env, bool value) {
-  napi_deferred deferred;
-  napi_value promise;
-  napi_create_promise(env, &deferred, &promise);
+  napi_deferred deferred = nullptr;
+  napi_value promise = nullptr;
+  if (napi_create_promise(env, &deferred, &promise) != napi_ok || !deferred) {
+    napi_throw_error(env, nullptr, "Failed to create promise");
+    return nullptr;
+  }
   napi_value result;
   napi_get_boolean(env, value, &result);
   napi_resolve_deferred(env, deferred, result);
@@ -189,9 +192,12 @@ inline napi_value BuildStringArray(napi_env env,
 
 inline napi_value MakeResolvedStringArrayPromise(
     napi_env env, const std::vector<std::string> &files) {
-  napi_deferred deferred;
-  napi_value promise;
-  napi_create_promise(env, &deferred, &promise);
+  napi_deferred deferred = nullptr;
+  napi_value promise = nullptr;
+  if (napi_create_promise(env, &deferred, &promise) != napi_ok || !deferred) {
+    napi_throw_error(env, nullptr, "Failed to create promise");
+    return nullptr;
+  }
   napi_value result = BuildStringArray(env, files);
   napi_resolve_deferred(env, deferred, result);
   return promise;

--- a/entry/src/main/cpp/common/config/file_configuration.cpp
+++ b/entry/src/main/cpp/common/config/file_configuration.cpp
@@ -4,6 +4,7 @@
 #include <cctype>
 #include <cstdio>
 #include <fstream>
+#include <unistd.h>
 
 namespace common {
 namespace {
@@ -90,9 +91,12 @@ bool FileConfiguration::LoadKeyValues(
 bool FileConfiguration::SaveKeyValues(
     const std::string &path,
     const std::map<std::string, std::string> &kv) {
-  FILE *fp = fopen(path.c_str(), "wb");
+  // 原子写入:先写临时文件,fsync 落盘,再 rename 原子替换。避免崩溃/断电
+  // 时直接 fopen("wb") 把目标文件截断为空导致配置丢失。
+  const std::string tmpPath = path + ".tmp";
+  FILE *fp = fopen(tmpPath.c_str(), "wb");
   if (!fp) {
-    LogConfigFailure("Config save failed: " + path);
+    LogConfigFailure("Config save failed (open tmp): " + tmpPath);
     return false;
   }
 
@@ -101,7 +105,15 @@ bool FileConfiguration::SaveKeyValues(
     fprintf(fp, "%s = \"%s\"\n", it.first.c_str(), escaped.c_str());
   }
 
+  fflush(fp);
+  fsync(fileno(fp));
   fclose(fp);
+
+  if (rename(tmpPath.c_str(), path.c_str()) != 0) {
+    LogConfigFailure("Config save failed (rename): " + path);
+    unlink(tmpPath.c_str());
+    return false;
+  }
   return true;
 }
 

--- a/entry/src/main/cpp/platform/audio/audio_bridge.cpp
+++ b/entry/src/main/cpp/platform/audio/audio_bridge.cpp
@@ -277,8 +277,11 @@ size_t AudioBridge::ProcessAudio(const int16_t *data, size_t frames) {
   }
   
   // 1.5 Bypass 重采样 (如果采样率相同)
-  // 注意：需要在锁内判断以安全访问 resampler_，写入逻辑保持一致
-  const bool bypass = (resampler_.GetRatio() == 1.0);
+  // 注意:不能仅用 resampler_.GetRatio() == 1.0 判断,因为 DRC 在 1.0 附近微调时
+  // ratio 与 1.0 浮点相等的概率不稳定,bypass 与否会跳变。
+  // 改用整数比较 core/output 采样率 + DRC skew 严格等于 1.0(初始未触发) 双重判定。
+  const bool bypass = (core_sample_rate_ == output_sample_rate_) &&
+                      (drc_skew_.load() == 1.0);
   const double ratio_snapshot = resampler_.GetCurrentRatio();
   size_t out_frames = 0;
 
@@ -446,16 +449,10 @@ size_t AudioBridge::ProcessAudio(const int16_t *data, size_t frames) {
         skew = std::max(skew - kDrcStep, static_cast<double>(kDrcMinSkew));
       }
       
-      // 更新 Ratio 需要加锁，因为 Resample 也在用
-      // 重新获取锁进行简短的更新
-      // 这里的竞争很小，因为只有这里会修改 ratio
-      // 实际上 Resample 和 UpdateRatio 都是在 ProcessAudio 线程调用的，
-      // 所以理论上是单线程的，除了 Reset 可能会在另一线程。
-      // 为安全起见，这里不需要 AudioBridge 的锁，Resampler 内部没有锁
-      // 但 Resample 和 UpdateRatio 都在 ProcessAudio 中调用，所以是序列化的。
-      // 唯一的风险是 Reset 在另一线程重置 Resampler。
-      // 考虑到 Reset 调用时 Core 应该已暂停或正在加载，风险可控。
+      // 更新 Ratio 需要加锁,因为 Reset() 可能在另一线程重置 Resampler。
+      // 原实现注释承认"风险可控"但实际是数据竞争 UB,这里恢复加锁。
       if (skew != drc_skew_.load()) {
+        std::lock_guard<std::mutex> drc_guard(mutex_);
         drc_skew_.store(skew);
         resampler_.UpdateRatio(skew);
         int32_t skew_ppm = static_cast<int32_t>(skew * 1000000.0);


### PR DESCRIPTION
## Summary
Six correctness fixes that address data race, NAPI crash, file truncation, and CI test infrastructure gap. Lower severity than PR #60 but still ship-blocking before next release.

- **H23** `CMakeLists.txt` — opt-in `libretro_tests` executable target (test suite was 100% disabled before)
- **M-E2** `audio_bridge.cpp` — DRC's \`resampler_.UpdateRatio\` now locks against \`Reset\` (was a documented data race)
- **M5** `audio_bridge.cpp` — bypass-resampling condition no longer relies on unstable float-equal of resampler ratio
- **M11** `engine_napi_common.h` — \`MakeResolvedPromise\`/\`MakeResolvedStringArrayPromise\` check \`napi_create_promise\` return value
- **M14** `plugin_manager.{h,cpp}` — \`nativeXComponentMap_\` protected by mutex (was unprotected across napi/UI threads)
- **M15** `file_configuration.cpp` — atomic write via tmp file + rename (prevents config truncation on crash)

## Test plan
- [ ] CI: \`hvigorw assembleHap\` green
- [ ] CI: \`cmake -DBUILD_LIBRETRO_TESTS=ON\` opt-in step succeeds (separate step, won't gate HAP)
- [ ] Manual: fast-forward toggle (which moves DRC ratio rapidly) — verify no audible glitches
- [ ] Manual: rapid XComponent attach/detach via JS — observe no plugin_manager map corruption
- [ ] Manual: kill app during settings save — verify config file isn't empty on next launch

## Notes
- Depends on PR #60 if you run actual tests against the resulting binary (H18 wiring is there).
- Independent of PR #60 for compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)