### PR TITLE
chore(robustness): video/audio/input/resource correctness fixes (9 M)

### DIFF
--- a/entry/src/main/cpp/common/cue_parser.cpp
+++ b/entry/src/main/cpp/common/cue_parser.cpp
@@ -64,6 +64,12 @@ std::vector<std::string> ParseCueReferencedFiles(const std::vector<uint8_t>& cue
             }
 
             if (!filename.empty()) {
+                // 拒绝路径遍历与绝对路径:解析结果会被调用方拼接到 cue 同级目录加载,
+                // 含 ".." 或绝对路径的项会导致越界访问。
+                if (filename.find("..") != std::string::npos ||
+                    filename[0] == '/' || filename[0] == '\\') {
+                    continue;
+                }
                 files.push_back(filename);
             }
         }

--- a/entry/src/main/cpp/core/engine/frame_pacer.h
+++ b/entry/src/main/cpp/core/engine/frame_pacer.h
@@ -52,6 +52,11 @@ public:
     }
     
     while (std::chrono::steady_clock::now() < target_end) {
+#if defined(__aarch64__) || defined(__arm__)
+      asm volatile("yield");
+#elif defined(__x86_64__) || defined(__i386__)
+      __builtin_ia32_pause();
+#endif
     }
   }
 

--- a/entry/src/main/cpp/core/engine/input_snapshot.h
+++ b/entry/src/main/cpp/core/engine/input_snapshot.h
@@ -20,8 +20,7 @@ public:
   InputSnapshot() {
     for (int port = 0; port < kMaxPorts; ++port) {
       buttons_mask_[port].store(0);
-      pointer_xy_[port].store(0);
-      pointer_pressed_[port].store(false);
+      pointer_state_[port].store(0);
       for (int i = 0; i < kMaxAnalogAxes; ++i) {
         analog_axes_[port][i].store(0);
       }
@@ -102,8 +101,7 @@ public:
       for (int i = 0; i < kMaxAnalogAxes; ++i) {
         analog_axes_[port][i].store(0, std::memory_order_relaxed);
       }
-      pointer_xy_[port].store(0, std::memory_order_relaxed);
-      pointer_pressed_[port].store(false, std::memory_order_relaxed);
+      pointer_state_[port].store(0, std::memory_order_relaxed);
       for (int i = 0; i < kMaxSensors; ++i) {
         sensor_values_[port][i].store(0.0f, std::memory_order_relaxed);
       }
@@ -121,8 +119,7 @@ public:
     for (int i = 0; i < kMaxAnalogAxes; ++i) {
       analog_axes_[port][i].store(0, std::memory_order_relaxed);
     }
-    pointer_xy_[port].store(0, std::memory_order_relaxed);
-    pointer_pressed_[port].store(false, std::memory_order_relaxed);
+    pointer_state_[port].store(0, std::memory_order_relaxed);
     for (int i = 0; i < kMaxSensors; ++i) {
       sensor_values_[port][i].store(0.0f, std::memory_order_relaxed);
     }
@@ -131,17 +128,22 @@ public:
   /**
    * @brief 设置指针状态 (Touch/Mouse)
    * 坐标应归一化到 [-0x8000, 0x7fff]
+   *
+   * 单原子 64-bit 打包 (xy + pressed),保证 GetPointer 不会读到"新坐标 + 旧
+   * pressed"撕裂状态(原 xy 与 pressed 分两个 atomic,可能跨 1 帧不一致)。
    */
   void SetPointer(int port, int16_t x, int16_t y, bool pressed) {
     if (!IsValidPort(port)) {
       return;
     }
-    // Pack X and Y into a single 32-bit integer for atomic update
-    // Low 16 bits: X, High 16 bits: Y
-    uint32_t packed =
-        (static_cast<uint16_t>(y) << 16) | static_cast<uint16_t>(x);
-    pointer_xy_[port].store(packed, std::memory_order_relaxed);
-    pointer_pressed_[port].store(pressed, std::memory_order_relaxed);
+    // 位布局: bit 63 = pressed, bits 31..16 = y, bits 15..0 = x
+    uint64_t packed =
+        (static_cast<uint64_t>(static_cast<uint16_t>(y)) << 16) |
+        static_cast<uint64_t>(static_cast<uint16_t>(x));
+    if (pressed) {
+      packed |= (1ULL << 63);
+    }
+    pointer_state_[port].store(packed, std::memory_order_relaxed);
   }
 
   /**
@@ -154,10 +156,10 @@ public:
       pressed = false;
       return;
     }
-    uint32_t packed = pointer_xy_[port].load(std::memory_order_relaxed);
+    uint64_t packed = pointer_state_[port].load(std::memory_order_relaxed);
     x = static_cast<int16_t>(packed & 0xFFFF);
-    y = static_cast<int16_t>(packed >> 16);
-    pressed = pointer_pressed_[port].load(std::memory_order_relaxed);
+    y = static_cast<int16_t>((packed >> 16) & 0xFFFF);
+    pressed = ((packed >> 63) & 1ULL) != 0;
   }
 
   /**
@@ -193,9 +195,9 @@ private:
   // 使用原子数组存储模拟量（支持 32 个轴）
   std::atomic<int16_t> analog_axes_[kMaxPorts][kMaxAnalogAxes];
 
-  // 指针状态
-  std::atomic<uint32_t> pointer_xy_[kMaxPorts];
-  std::atomic<bool> pointer_pressed_[kMaxPorts];
+  // 指针状态 (xy + pressed 打包到单个 64-bit atomic,避免跨原子撕裂)
+  // 位布局: bit 63 = pressed, bits 31..16 = y, bits 15..0 = x
+  std::atomic<uint64_t> pointer_state_[kMaxPorts];
 
   // 传感器数据 (支持 16 个通道，足以覆盖 Accel(3) + Gyro(3) + Light(1) + others)
   std::atomic<float> sensor_values_[kMaxPorts][kMaxSensors];

--- a/entry/src/main/cpp/core/engine/video_pipeline.cpp
+++ b/entry/src/main/cpp/core/engine/video_pipeline.cpp
@@ -1410,7 +1410,11 @@ VideoPipeline::Render(OHNativeWindow *window, const void *data, unsigned width,
 #endif
   const auto now = std::chrono::steady_clock::now();
   MaybeRecoverDegradedMode(mode, now);
-  const bool isDupeRequest = (data == RETRO_HW_FRAME_BUFFER_VALID); // Simplified
+  // 注意:命名为 isDupeRequest 但实际语义是"HW 有效帧标记"。按 libretro 协议
+  // dupe 是 (data == NULL),但 line 1399 已把 NULL 直接当 no-op RENDERED 返回,
+  // 因此此处只剩 HW 有效帧的语义。彻底协议化的 dupe 处理(在 NULL 时复用上帧)
+  // 留作后续单独 PR,需同步评估 GLES/Vulkan 路径的 DUPED 返回值含义。
+  const bool isDupeRequest = (data == RETRO_HW_FRAME_BUFFER_VALID);
   const auto preflightReason =
       EvaluateRenderPreflight(window, width, height, pitch, mode, isDupeRequest);
   if (preflightReason != PreflightDropReason::NONE) {

--- a/entry/src/main/cpp/platform/audio/audio_player.cpp
+++ b/entry/src/main/cpp/platform/audio/audio_player.cpp
@@ -980,10 +980,9 @@ void AudioPlayer::Cleanup() {
   ring_buffer_ = nullptr;
   running_ = nullptr;
 
-  {
-    std::lock_guard<std::mutex> lock(callback_mutex_);
-    shutting_down_ = false;
-  }
+  // 注意:不再把 shutting_down_ 重置为 false。Cleanup 是单次最终态,
+  // 残留 OHAudio 回调必须通过 shutting_down_ == true 检查拦截,
+  // 避免回调访问已置 nullptr 的 ring_buffer_。
 }
 
 } // namespace libretro

--- a/entry/src/main/cpp/platform/graphics/graphics_context.cpp
+++ b/entry/src/main/cpp/platform/graphics/graphics_context.cpp
@@ -215,6 +215,14 @@ bool GraphicsContext::SwapBuffers() {
 }
 
 bool GraphicsContext::UpdateSurface(OHNativeWindow *window) {
+  // 上下文未就绪时直接拒绝,避免 CreateSurface 内部 eglMakeCurrent 用
+  // EGL_NO_CONTEXT 失败但失败原因不可观测。
+  if (!ready_ || egl_context_ == EGL_NO_CONTEXT) {
+    LOGF(LOG_ERROR,
+         "UpdateSurface called before context is ready (ready=%{public}d)",
+         ready_ ? 1 : 0);
+    return false;
+  }
   // Recreate surface simply calls CreateSurface which handles destruction of
   // old one. Assuming context is preserved.
   return CreateSurface(window);

--- a/entry/src/main/cpp/platform/graphics/hw_render_presenter.cpp
+++ b/entry/src/main/cpp/platform/graphics/hw_render_presenter.cpp
@@ -235,7 +235,9 @@ void HwRenderPresenter::Present(int viewport_width, int viewport_height,
   const float v_top = config_.bottom_left_origin ? v_max : 0.0f;
   const float v_bottom = config_.bottom_left_origin ? 0.0f : v_max;
 
-  // GLStateBackup state = CaptureState(attrib_pos_, attrib_tex_); // Removed to avoid pipeline stall
+  // 恢复 Core GL 状态备份(Viewport/Blend/Depth/Scissor/Cull/Program/FBO 等),
+  // 避免 Present 内 glDisable/glClear 等操作污染 Core 协议假设。
+  GLStateBackup state = CaptureState(attrib_pos_, attrib_tex_);
 
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   glViewport(0, 0, viewport_width, viewport_height);
@@ -270,7 +272,7 @@ void HwRenderPresenter::Present(int viewport_width, int viewport_height,
 
   glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-  // RestoreState(state, attrib_pos_, attrib_tex_); // Removed
+  RestoreState(state, attrib_pos_, attrib_tex_);
   // Restore FBO binding for the core
   glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
 }

--- a/entry/src/main/cpp/platform/resource/rawfile_rom_processor.cpp
+++ b/entry/src/main/cpp/platform/resource/rawfile_rom_processor.cpp
@@ -97,7 +97,9 @@ RawfileRomProcessor::Result RawfileRomProcessor::Process(
 
   TempFileManager temp_mgr(files_dir);
   if (!temp_mgr.Initialize()) {
-    LOGF(LOG_WARN, "TempFileManager failed to initialize");
+    LOGF(LOG_WARN,
+         "TempFileManager failed to initialize, skip temp ROM write");
+    return result;  // 内存数据已加载,直接返回,不再尝试写盘
   }
 
   std::string temp_path;

--- a/entry/src/main/cpp/platform/resource/rom_loader.h
+++ b/entry/src/main/cpp/platform/resource/rom_loader.h
@@ -52,10 +52,21 @@ public:
                                        NativeResourceManager *resource_manager);
 
   /**
-   * 创建 retro_game_info 结构体
-   * @param result ROM 加载结果
+   * 创建 retro_game_info 结构体。
+   *
+   * **重要 - 生命周期契约**:
+   * 返回的 retro_game_info 内 `.path` / `.data` 是指向 `result` 内部缓冲区的
+   * **裸指针**,本函数不持有所有权。调用方 **必须保证 `result` 在 retro_load_game
+   * 返回前持续存活**,否则核心将访问悬空内存。
+   *
+   * 典型正确用法:
+   *   ROMLoadResult result = ... ;        // 调用方栈/堆变量
+   *   auto info = ROMLoader::CreateGameInfo(result, need_fullpath);
+   *   bool ok = core.retro_load_game(&info);   // result 仍在作用域内
+   *
+   * @param result ROM 加载结果(必须比返回值存活更久)
    * @param need_fullpath 核心是否需要完整路径
-   * @return retro_game_info 结构体
+   * @return retro_game_info 结构体(含指向 result 内部数据的裸指针)
    */
   static retro_game_info CreateGameInfo(const ROMLoadResult &result,
                                         bool need_fullpath);


### PR DESCRIPTION
## Summary
Nine independent correctness/robustness fixes. Low risk, each is small.

- **M-E3** \`hw_render_presenter.cpp\` — restore GLStateBackup capture/restore so Present doesn't trash Core GL state
- **M3** \`video_pipeline.cpp\` — document \`isDupeRequest\` actual semantics (protocol-correct dupe is follow-up PR)
- **M4** \`frame_pacer.h\` — busy-wait uses \`yield\`/\`pause\` hints on aarch64/x86
- **M5** \`audio_player.cpp\` — Cleanup no longer flips \`shutting_down_\` back to false
- **M7** \`graphics_context.cpp\` — UpdateSurface rejects on \`!ready_\` instead of silent failure
- **M8** \`rom_loader.h\` — document retro_game_info lifetime contract
- **M9** \`rawfile_rom_processor.cpp\` — early-return when TempFileManager init fails
- **M10** \`input_snapshot.h\` — pack pointer state (pressed+xy) into a single 64-bit atomic
- **M16** \`cue_parser.cpp\` — reject \`..\` and absolute paths in cue file entries

## Test plan
- [ ] CI: \`hvigorw assembleHap\` green
- [ ] Manual: HW-render core (e.g., N64/PSX with GLES context) — verify Core GL state isn't broken across frames
- [ ] Manual: touch/mouse rapid press-release — verify pointer state doesn't tear
- [ ] Manual: load malicious .cue (with \`../\` entry) — verify rejected
- [ ] Manual: rapid Init/Cleanup of AudioPlayer — verify no UAF in callback

## Notes
Each fix is small and could in theory be its own PR, but they bundle well as a single "robustness sweep" PR since none of them interact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)