### PR TITLE
ci(workflow): add BUILD_LIBRETRO_TESTS=ON build step

### DIFF
--- a/.github/workflows/harmonyos-pr-ci.yml
+++ b/.github/workflows/harmonyos-pr-ci.yml
@@ -89,6 +89,13 @@ jobs:
           HARMONY_MODULE_TARGET: entry@default
         run: bash scripts/ci/build_harmony_hap.sh
 
+      - name: Build Libretro Tests (BUILD_LIBRETRO_TESTS=ON)
+        continue-on-error: true
+        shell: bash
+        run: |
+          cmake -S entry/src/main/cpp -B build/cpp-tests -DBUILD_LIBRETRO_TESTS=ON
+          cmake --build build/cpp-tests --target libretro_tests
+
       - name: Prepare Signing Material
         id: signprep
         shell: bash


### PR DESCRIPTION
## Summary
- 在 `harmonyos-pr-ci.yml` 加独立 cmake step，显式 `-DBUILD_LIBRETRO_TESTS=ON` 编译测试 target
- 配合 #61 的 H23（opt-in 测试 target），让 CI 真正验证测试代码不会编译失败
- `continue-on-error: true`：步骤失败不挂主 HAP 构建，但在 PR check 可见

## Test plan
- [ ] CI 跑过本步骤，确认测试 target 链接成功
- [ ] 故意改坏一处测试代码确认本 step 能捕获

Refs #61