### PR TITLE
fix(reactivity+a11y): H-level audit fixes for state reactivity and touch targets

### DIFF
--- a/entry/src/main/ets/components/RuntimeVirtualControllerLayer.ets
+++ b/entry/src/main/ets/components/RuntimeVirtualControllerLayer.ets
@@ -260,6 +260,12 @@ export struct RuntimeVirtualControllerLayer {
       style: BorderStyle.Solid
     })
     .borderRadius(radius)
+    .responseRegion({
+      width: Math.max(buttonWidth, 44),
+      height: Math.max(buttonHeight, 44),
+      x: buttonWidth >= 44 ? 0 : (buttonWidth - 44) / 2,
+      y: buttonHeight >= 44 ? 0 : (buttonHeight - 44) / 2
+    })
     .shadow({
       radius: this.isPrimaryRuntimeButton(buttonId) ? 18 : 10,
       color: this.isPrimaryRuntimeButton(buttonId) ? '#4400FF41' : '#99000000',

--- a/entry/src/main/ets/pages/LibraryPage.ets
+++ b/entry/src/main/ets/pages/LibraryPage.ets
@@ -132,7 +132,7 @@ struct LibraryPage {
   private cardLongPressed: boolean = false
   private cachedFilteredGames: LibraryRecord[] = []
   private cachedFilteredRecentGames: LibraryRecord[] = []
-  private cachedSearchResults: LibraryRecord[] = []
+  @State private cachedSearchResults: LibraryRecord[] = []
   private cachedDisplayPlatformFilters: string[] = []
   aboutToAppear(): void {
     this.pageActive = true

--- a/entry/src/main/ets/pages/LibretroGamePage.ets
+++ b/entry/src/main/ets/pages/LibretroGamePage.ets
@@ -498,7 +498,7 @@ struct LibretroGamePage {
   handleFpsUpdate(payload: FpsUpdatePayload) {
     const fps = Number(payload.fps);
     if (!Number.isNaN(fps)) {
-      this.perfDisplay.coreFps = Math.round(fps);
+      this.perfDisplay = { ...this.perfDisplay, coreFps: Math.round(fps) };
       this.refreshHudMetricsCache();
     }
 
@@ -510,7 +510,7 @@ struct LibretroGamePage {
     const buf = Number(payload.audioBufferUsage ?? 0);
     this.librarySessionTracker.updateFrameStats(fps, drops, dupes, nulls, underruns, overruns, buf);
 
-    this.perfDisplay.perfStatsText = `D:${drops} Du:${dupes} N:${nulls} U/O:${underruns}/${overruns} Buf:${buf.toFixed(0)}%`;
+    this.perfDisplay = { ...this.perfDisplay, perfStatsText: `D:${drops} Du:${dupes} N:${nulls} U/O:${underruns}/${overruns} Buf:${buf.toFixed(0)}%` };
   }
 
   handleAudioStatus(payload: AudioStatusPayload) {
@@ -520,7 +520,7 @@ struct LibretroGamePage {
       return;
     }
     this.librarySessionTracker.updateAudioStatus(occupancy, underruns, Number(payload.overruns));
-    this.perfDisplay.audioStatusText = `Buf:${occupancy.toFixed(0)}% U:${underruns}`;
+    this.perfDisplay = { ...this.perfDisplay, audioStatusText: `Buf:${occupancy.toFixed(0)}% U:${underruns}` };
   }
 
   handleGeometryUpdate(payload: GeometryUpdatePayload) {
@@ -529,7 +529,7 @@ struct LibretroGamePage {
     const a = Number(payload.aspect_ratio ?? 0);
     if (w > 0 && h > 0) {
       const aspectText = (a > 0) ? a.toFixed(3) : (w / h).toFixed(3);
-      this.perfDisplay.geometryText = `Base:${w}x${h} AR:${aspectText}`;
+      this.perfDisplay = { ...this.perfDisplay, geometryText: `Base:${w}x${h} AR:${aspectText}` };
     }
   }
 
@@ -654,34 +654,31 @@ struct LibretroGamePage {
     }
     const core = this.cores[this.selectedCoreIndex];
     if (!core) {
-      this.coreCheck.text = '核心无效';
+      this.coreCheck = { ...this.coreCheck, text: '核心无效' };
       return;
     }
-    this.coreCheck.running = true;
-    this.coreCheck.text = '正在验证核心符号...';
+    this.coreCheck = { ...this.coreCheck, running: true, text: '正在验证核心符号...' };
     try {
       const context = this.getUIContext().getHostContext() as common.UIAbilityContext;
       if (!context) {
-        this.coreCheck.text = '获取 Context 失败';
-        this.coreCheck.running = false;
+        this.coreCheck = { ...this.coreCheck, text: '获取 Context 失败', running: false };
         return;
       }
       const bundleCodeDir = context.bundleCodeDir;
       const corePath = await resolveRuntimeCorePath(bundleCodeDir, core.soFile);
       const result = runtimeCoreDiagnosticController.testCoreLoader(corePath);
-      this.coreCheck.text = result;
+      this.coreCheck = { ...this.coreCheck, text: result };
     } catch (e) {
       const msg = (e as Error)?.message || String(e);
-      this.coreCheck.text = `Failed: ${msg}`;
+      this.coreCheck = { ...this.coreCheck, text: `Failed: ${msg}` };
       LogHelper.error('LibretroGame', 'Core', `符号验证异常: ${msg}`);
     } finally {
-      this.coreCheck.running = false;
+      this.coreCheck = { ...this.coreCheck, running: false };
     }
   }
 
   private resetCoreCheckState() {
-    this.coreCheck.running = false;
-    this.coreCheck.text = '';
+    this.coreCheck = { running: false, text: '' };
   }
 
   private getRuntimeFpsText(): string {
@@ -747,11 +744,13 @@ struct LibretroGamePage {
 
   private clearRuntimeStatsForConfigChange(): void {
     const okStats = runtimeRenderSettingsController.resetStats();
-    this.perfDisplay.realtimeFps = 0;
-    this.perfDisplay.coreFps = 0;
-    this.perfDisplay.audioStatusText = '';
-    this.perfDisplay.perfStatsText = '';
-    this.perfDisplay.geometryText = '';
+    this.perfDisplay = {
+      realtimeFps: 0,
+      coreFps: 0,
+      audioStatusText: '',
+      perfStatsText: '',
+      geometryText: ''
+    };
     LogHelper.info('LibretroGame', 'Config', `重置性能统计: okStats=${okStats}`);
   }
 
@@ -1277,8 +1276,10 @@ struct LibretroGamePage {
   }
 
   private applySoakState(state: RuntimeSoakState): void {
-    this.soakState.running = state.running;
-    this.soakState.secondsLeft = state.secondsLeft;
-    this.soakState.summaryText = state.summaryText;
+    this.soakState = {
+      running: state.running,
+      secondsLeft: state.secondsLeft,
+      summaryText: state.summaryText
+    };
   }
 }


### PR DESCRIPTION
## Summary
Fixes 3 of 4 H-level findings from the 2026-05-22 audit (refs #68):

- **H-1** ``LibretroGamePage`` plain-interface ``@State`` field-path assignment not triggering reactive updates -> switched 22 sites (coreCheck x10, perfDisplay x9, soakState x3) to whole-object spread ``this.x = { ...this.x, field: val }`` so ArkTS V1 first-level dependency tracking fires. This is a real functional bug: HUD/perf/core-check text previously did not refresh.
- **H-2** ``LibrarySearchPanel`` ``cachedSearchResults`` declared ``private`` instead of ``@State private`` -> one-line fix; without the decorator, child ``@Prop searchResults`` never refreshed.
- **H-4** ``RuntimeVirtualControllerLayer`` dpad 24x24 vp touch targets below WCAG/HMI minimum -> added ``.responseRegion`` inside ``RuntimeInputButtonById`` builder so every button under 44 vp gets a >=44 vp response area while keeping the visual size unchanged.

## Deferred
**H-3** (``LibretroNewArchTestPage`` ``build()`` 723 lines) requires extracting multiple large ``@Builder`` blocks across ~500 lines. Tracked as a separate follow-up PR to keep this change cleanly reviewable.

## Test plan
- [ ] HUD on ``LibretroGamePage`` updates fps/audio/geometry text in real time (no longer stale at initial values)
- [ ] Core check text updates as ``triggerCoreCheck()`` progresses (Validating -> result text)
- [ ] Soak test running/secondsLeft/summary updates while running
- [ ] Search results refresh while typing in ``LibraryPage`` search box
- [ ] Dpad buttons easier to press on small phones (visual unchanged, response region expanded)
- [ ] No regression in pause/resume, core load, or virtual gamepad input

Refs #68