### PR TITLE
perf(canvas+async): decorative ForEach -> Canvas + sync SaveState -> async

### DIFF
--- a/entry/src/main/ets/components/LibraryDetailInfoPanel.ets
+++ b/entry/src/main/ets/components/LibraryDetailInfoPanel.ets
@@ -1,4 +1,5 @@
 import { createIndexRange, EmuColors } from '../common/EmuUiTokens'
+import { GridBackground } from './EmuAppShell'
 
 interface TelemetryPoint {
   x: number
@@ -166,29 +167,11 @@ export struct LibraryDetailInfoPanel {
       .justifyContent(FlexAlign.SpaceBetween)
 
       Stack() {
-        Row({ space: 23 }) {
-          ForEach(this.telemetryVerticalLines, (_: number) => {
-            Column()
-              .width(1)
-              .height('100%')
-              .backgroundColor('#112C2C2C')
-          }, (index: number) => `v-${index}`)
-        }
-        .width('100%')
-        .height('100%')
-
-        Column({ space: 16 }) {
-          ForEach(this.telemetryHorizontalLines, (_: number) => {
-            Row()
-              .width('100%')
-              .height(1)
-              .backgroundColor('#142C2C2C')
-          }, (index: number) => index.toString())
-        }
-        .width('100%')
-        .height('100%')
-        .padding({ top: 16, bottom: 16 })
-        .justifyContent(FlexAlign.SpaceBetween)
+        GridBackground({
+          gridSize: 40,
+          lineColor: '#142C2C2C',
+          lineWidth: 1
+        })
 
         Path({
           width: 440,

--- a/entry/src/main/ets/components/RuntimePauseOverlay.ets
+++ b/entry/src/main/ets/components/RuntimePauseOverlay.ets
@@ -1,4 +1,5 @@
 import { EmuColors } from '../common/EmuUiTokens'
+import { GridBackground } from './EmuAppShell'
 
 interface RuntimePauseAction {
   title: string
@@ -301,27 +302,11 @@ export struct RuntimePauseOverlay {
   @Builder
   private WaveformGrid() {
     Stack() {
-      Row({ space: 19 }) {
-        ForEach(this.waveformVerticalIndexes, (item: number) => {
-          Column()
-            .width(1)
-            .height('100%')
-            .backgroundColor('#1600FF41')
-        }, (item: number) => `v-${item}`)
-      }
-      .width('100%')
-      .height('100%')
-
-      Column({ space: 19 }) {
-        ForEach(this.waveformHorizontalIndexes, (item: number) => {
-          Row()
-            .width('100%')
-            .height(1)
-            .backgroundColor('#1600FF41')
-        }, (item: number) => `h-${item}`)
-      }
-      .width('100%')
-      .height('100%')
+      GridBackground({
+        gridSize: 40,
+        lineColor: '#1600FF41',
+        lineWidth: 1
+      })
     }
     .width('100%')
     .height('100%')

--- a/entry/src/main/ets/pages/SaveStatePage.ets
+++ b/entry/src/main/ets/pages/SaveStatePage.ets
@@ -12,6 +12,7 @@ import {
 } from '../common/SaveStateRepository'
 import { getEmuBottomNavTargetRoute } from '../common/RouteHelper'
 import LogHelper from '../common/LogHelper'
+import { runtimeSessionController } from '../common/RuntimeSessionController'
 
 interface SaveStateNapi {
   refactoredSaveState(): ArrayBuffer | null
@@ -246,7 +247,7 @@ struct SaveStatePage {
       return
     }
     try {
-      const stateData = nativeApi.refactoredSaveState()
+      const stateData = await runtimeSessionController.saveStateAsync()
       if (!stateData || stateData.byteLength <= 0) {
         this.showToastMessage('SAVE_STATE_UNAVAILABLE')
         return

--- a/entry/src/main/ets/pages/ShaderPreviewPage.ets
+++ b/entry/src/main/ets/pages/ShaderPreviewPage.ets
@@ -1,5 +1,5 @@
 import { EmuBottomNav, EmuBottomNavItem } from '../components/EmuBottomNav'
-import { EmuHeaderBar } from '../components/EmuAppShell'
+import { EmuHeaderBar, ScanlineBackground } from '../components/EmuAppShell'
 import { EmuColors } from '../common/EmuUiTokens'
 import { getEmuBottomNavTargetRoute } from '../common/RouteHelper'
 
@@ -81,17 +81,10 @@ struct ShaderPreviewPage {
         })
 
       if (processed) {
-        Column({ space: 3 }) {
-          ForEach(this.scanlineRows, (item: number) => {
-            Row()
-              .width('100%')
-              .height(1)
-              .backgroundColor('#55000000')
-              .opacity(0.5)
-          }, (item: number) => `scan-${item}`)
-        }
-        .width('100%')
-        .height('100%')
+        ScanlineBackground({
+          lineColor: '#55000000',
+          lineSpacing: 4
+        })
       }
 
       Column({ space: 10 }) {


### PR DESCRIPTION
## Summary
M-level performance optimizations from the 2026-05-22 audit (refs #68):

**Decorative ForEach -> Canvas (3 sites)**
- ``LibraryDetailInfoPanel.ets``: 17 ForEach lines (13 vertical + 4 horizontal) -> ``GridBackground`` (1 Canvas)
- ``RuntimePauseOverlay.ets``: 13 ForEach lines (WaveformGrid 8+5) -> ``GridBackground``
- ``ShaderPreviewPage.ets``: 12 ForEach scanlines -> ``ScanlineBackground``

**Sync SaveState -> async (1 site)**
- ``SaveStatePage.ets:249`` quickSave path switched from sync ``refactoredSaveState()`` to ``await runtimeSessionController.saveStateAsync()`` to avoid blocking the main thread on large savestates. ``RuntimeSessionController`` already wraps the native async-work pipeline, used elsewhere in the project.

## Why
- Decorative ForEach allocates range arrays and creates 12-17 lightweight components per render. Canvas draws the equivalent visual in a single reusable component, removing per-frame component construction overhead.
- Sync napi savestate can block the UI thread >16ms; async pipeline already exists and is mature.

## Notes
GridBackground uses uniform grid spacing; original ForEach used non-uniform 13x4 / 8x5 spacing. Acceptable visual difference for decorative backgrounds; if the design team prefers non-uniform, follow-up can parameterize GridBackground with separate ``rowSpacing`` / ``colSpacing``.

## Test plan
- [ ] LibraryDetailInfoPanel telemetry grid still visually present
- [ ] RuntimePauseOverlay waveform grid still visually present
- [ ] ShaderPreviewPage scanlines still rendered
- [ ] SaveStatePage quick save: verify async path returns ArrayBuffer and the toast/manifest flow still works
- [ ] No regression on memory/CPU during normal navigation

Refs #68